### PR TITLE
Add base structure of risk report getting

### DIFF
--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -27,6 +27,40 @@ const paramsSchemaForCandlesApi = {
   }
 }
 
+const paramsSchemaForRiskApi = {
+  type: 'object',
+  properties: {
+    timeframe: {
+      type: 'string',
+      enum: [
+        'day',
+        'month',
+        'year'
+      ]
+    },
+    start: {
+      type: 'integer'
+    },
+    end: {
+      type: 'integer'
+    },
+    skip: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'string',
+        enum: [
+          'trades',
+          'marginTrades',
+          'fundingPayment',
+          'movementFees'
+        ]
+      }
+    }
+  }
+}
+
 module.exports = {
-  paramsSchemaForCandlesApi
+  paramsSchemaForCandlesApi,
+  paramsSchemaForRiskApi
 }

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -15,6 +15,7 @@ const {
   checkParams,
   getMethodLimit
 } = require('./helpers')
+const getRisk = require('./sync/get-risk')
 
 class MediatorReportService extends BaseMediatorReportService {
   async _getCandles (args) {
@@ -57,6 +58,28 @@ class MediatorReportService extends BaseMediatorReportService {
       return res
     } catch (err) {
       this._err(err, '_getCandles')
+    }
+  }
+
+  async getRisk (space, args, cb) {
+    try {
+      // TODO: maybe need to improve
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        cb(null, { isSyncModeWithoutDbData: true })
+
+        return
+      }
+
+      checkParams(args, 'paramsSchemaForRiskApi')
+
+      const res = await getRisk(
+        this.dao,
+        args
+      )
+
+      cb(null, res)
+    } catch (err) {
+      this._err(err, 'getRisk', cb)
     }
   }
 }

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -10,6 +10,9 @@ const {
   getDateNotMoreNow,
   prepareResponse
 } = require('bfx-report/workers/loc.api/helpers')
+const {
+  DuringSyncMethodAccessError
+} = require('bfx-report/workers/loc.api/errors')
 
 const {
   checkParams,
@@ -63,11 +66,8 @@ class MediatorReportService extends BaseMediatorReportService {
 
   async getRisk (space, args, cb) {
     try {
-      // TODO: maybe need to improve
       if (!await this.isSyncModeWithDbData(space, args)) {
-        cb(null, { isSyncModeWithoutDbData: true })
-
-        return
+        throw new DuringSyncMethodAccessError()
       }
 
       checkParams(args, 'paramsSchemaForRiskApi')

--- a/workers/loc.api/sync/get-risk/get-funding-payment.js
+++ b/workers/loc.api/sync/get-risk/get-funding-payment.js
@@ -1,0 +1,8 @@
+'use strict'
+
+// TODO: returns just mock data for now
+module.exports = async (dao, args) => {
+  const res = { EUR: -400, JPY: 100, GBP: 100, USD: 2000 }
+
+  return res
+}

--- a/workers/loc.api/sync/get-risk/get-funding-payment.js
+++ b/workers/loc.api/sync/get-risk/get-funding-payment.js
@@ -2,7 +2,28 @@
 
 // TODO: returns just mock data for now
 module.exports = async (dao, args) => {
-  const res = { EUR: -400, JPY: 100, GBP: 100, USD: 2000 }
+  const res = [
+    {
+      mts: Date.UTC(2018, 11, 1),
+      vals: { EUR: -100, JPY: 500, GBP: 100, USD: 5000 }
+    },
+    {
+      mts: Date.UTC(2018, 11, 2),
+      vals: { EUR: -200, JPY: 400, GBP: 200, USD: 4000 }
+    },
+    {
+      mts: Date.UTC(2018, 11, 3),
+      vals: { EUR: -300, JPY: 300, GBP: 300, USD: 3000 }
+    },
+    {
+      mts: Date.UTC(2018, 11, 4),
+      vals: { EUR: -400, JPY: 200, GBP: 400, USD: 2000 }
+    },
+    {
+      mts: Date.UTC(2018, 11, 5),
+      vals: { EUR: -500, JPY: 100, GBP: 500, USD: 1000 }
+    }
+  ]
 
   return res
 }

--- a/workers/loc.api/sync/get-risk/get-margin-trades.js
+++ b/workers/loc.api/sync/get-risk/get-margin-trades.js
@@ -2,7 +2,32 @@
 
 // TODO: returns just mock data for now
 module.exports = async (dao, args) => {
-  const res = { EUR: -400, JPY: 100, GBP: 100, USD: 2000 }
+  const res = [
+    {
+      mts: Date.UTC(2018, 11, 2),
+      vals: { JPY: 500, GBP: 100, USD: 5000 }
+    },
+    {
+      mts: Date.UTC(2018, 11, 3),
+      vals: { EUR: -200, JPY: 400, GBP: 200, USD: 4000 }
+    },
+    {
+      mts: Date.UTC(2018, 11, 4),
+      vals: { EUR: -300, JPY: 300, GBP: 300 }
+    },
+    {
+      mts: Date.UTC(2018, 11, 5),
+      vals: { EUR: -400, JPY: 200, GBP: 400, USD: 2000 }
+    },
+    {
+      mts: Date.UTC(2018, 11, 6),
+      vals: { EUR: -500, JPY: 100, GBP: 500, USD: 1000 }
+    },
+    {
+      mts: Date.UTC(2018, 11, 7),
+      vals: { EUR: -600, GBP: 600 }
+    }
+  ]
 
   return res
 }

--- a/workers/loc.api/sync/get-risk/get-margin-trades.js
+++ b/workers/loc.api/sync/get-risk/get-margin-trades.js
@@ -1,0 +1,8 @@
+'use strict'
+
+// TODO: returns just mock data for now
+module.exports = async (dao, args) => {
+  const res = { EUR: -400, JPY: 100, GBP: 100, USD: 2000 }
+
+  return res
+}

--- a/workers/loc.api/sync/get-risk/get-movement-fees.js
+++ b/workers/loc.api/sync/get-risk/get-movement-fees.js
@@ -1,0 +1,8 @@
+'use strict'
+
+// TODO: returns just mock data for now
+module.exports = async (dao, args) => {
+  const res = { EUR: -400, JPY: 100, GBP: 100, USD: 2000 }
+
+  return res
+}

--- a/workers/loc.api/sync/get-risk/get-movement-fees.js
+++ b/workers/loc.api/sync/get-risk/get-movement-fees.js
@@ -2,7 +2,7 @@
 
 // TODO: returns just mock data for now
 module.exports = async (dao, args) => {
-  const res = { EUR: -400, JPY: 100, GBP: 100, USD: 2000 }
+  const res = []
 
   return res
 }

--- a/workers/loc.api/sync/get-risk/get-trades.js
+++ b/workers/loc.api/sync/get-risk/get-trades.js
@@ -2,7 +2,7 @@
 
 // TODO: returns just mock data for now
 module.exports = async (dao, args) => {
-  const res = { EUR: -400, JPY: 100, GBP: 100, USD: 2000 }
+  const res = null
 
   return res
 }

--- a/workers/loc.api/sync/get-risk/get-trades.js
+++ b/workers/loc.api/sync/get-risk/get-trades.js
@@ -1,0 +1,8 @@
+'use strict'
+
+// TODO: returns just mock data for now
+module.exports = async (dao, args) => {
+  const res = { EUR: -400, JPY: 100, GBP: 100, USD: 2000 }
+
+  return res
+}

--- a/workers/loc.api/sync/get-risk/index.js
+++ b/workers/loc.api/sync/get-risk/index.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const getTrades = require('./get-trades')
+const getMarginTrades = require('./get-margin-trades')
+const getFundingPayment = require('./get-funding-payment')
+const getMovementFees = require('./get-movement-fees')
+
+const _getData = async (dao, args) => {
+  const { skip } = { ...args.params }
+  const map = {
+    trades: getTrades,
+    marginTrades: getMarginTrades,
+    fundingPayment: getFundingPayment,
+    movementFees: getMovementFees
+  }
+  const res = {}
+
+  for (const [key, getter] of Object.entries(map)) {
+    if (
+      Array.isArray(skip) &&
+      skip.some(item => item === key)
+    ) {
+      continue
+    }
+
+    res[key] = await getter(dao, args)
+  }
+
+  return res
+}
+
+// TODO: need to implement response calculation
+module.exports = async (dao, args = {}) => {
+  const data = await _getData(dao, args)
+  const res = { ...data }
+
+  return res
+}

--- a/workers/loc.api/sync/get-risk/index.js
+++ b/workers/loc.api/sync/get-risk/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { pick, omit, orderBy } = require('lodash')
+
 const getTrades = require('./get-trades')
 const getMarginTrades = require('./get-margin-trades')
 const getFundingPayment = require('./get-funding-payment')
@@ -29,10 +31,108 @@ const _getData = async (dao, args) => {
   return res
 }
 
-// TODO: need to implement response calculation
+const _getDataKeys = (data) => {
+  return Object.keys(data)
+    .filter(key => (
+      Array.isArray(data[key]) &&
+      data[key].length > 0
+    ))
+}
+
+const _getMaxLength = (data) => {
+  const dataArr = Object.values(data)
+
+  if (dataArr.length === 0) {
+    return 0
+  }
+
+  return Math.max(
+    ...dataArr.map(item => item.length)
+  )
+}
+
+const _mergeData = (data) => {
+  if (
+    !data ||
+    typeof data !== 'object'
+  ) {
+    return []
+  }
+
+  const dataKeys = _getDataKeys(data)
+  const _data = pick(data, dataKeys)
+  const maxLength = _getMaxLength(_data)
+  const res = []
+
+  for (let i = 0; maxLength > i; i += 1) {
+    dataKeys.forEach(key => {
+      const { mts, vals } = { ..._data[key][i] }
+
+      if (
+        !Number.isInteger(mts) ||
+        !vals ||
+        typeof vals !== 'object' ||
+        Object.keys(vals).length === 0
+      ) {
+        return
+      }
+      if (
+        res.length === 0 ||
+        res.every(item => mts !== item.mts)
+      ) {
+        res.push({
+          mts,
+          [key]: { ...vals }
+        })
+
+        return
+      }
+
+      res.forEach((item, index) => {
+        if (mts === item.mts) {
+          res[index] = {
+            ...item,
+            [key]: { ...vals }
+          }
+        }
+      })
+    })
+  }
+
+  return orderBy(res, ['mts'], ['desc'])
+}
+
+const _calcData = (data) => {
+  const _data = _mergeData(data)
+  return _data.map(item => {
+    const res = Object.values(omit(item, ['mts']))
+      .reduce((accum, curr) => {
+        Object.entries(curr).forEach(([symb, val]) => {
+          if (!Number.isFinite(val)) {
+            return
+          }
+          if (Number.isFinite(accum[symb])) {
+            accum[symb] += val
+
+            return
+          }
+
+          accum[symb] = val
+        })
+
+        return accum
+      }, {})
+
+    return {
+      mts: item.mts,
+      ...res
+    }
+  })
+}
+
 module.exports = async (dao, args = {}) => {
   const data = await _getData(dao, args)
-  const res = { ...data }
+  const res = _calcData(data)
 
   return res
 }


### PR DESCRIPTION
This PR adds a base structure of risk report getting:
  - adds `getRisk(start, end, timeframe, skip)` service method
  - adds `trades`, `marginTrades`, `fundingPayment`, `movementFees` sub-calculations, with mock data for now
  - for each forex currency, we sum these 4 sub-calculations but be able to skip any of them

Dependencies:
  - with this PR need to merge this PR: [bitfinexcom/bfx-report#106](https://github.com/bitfinexcom/bfx-report/pull/106)
  - with this PR need to merge this PR: [bitfinexcom/bfx-report-express#4](https://github.com/bitfinexcom/bfx-report-express/pull/4)