### PR TITLE
Fix process.send for test

### DIFF
--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -1,5 +1,9 @@
 'use strict'
 
+if (typeof process.send !== 'function') {
+  process.send = () => {}
+}
+
 const WrkReportServiceApi = require(
   'bfx-report/workers/api.service.report.wrk'
 )

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -127,6 +127,8 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
 
     this.scheduler_sync.add(name, () => sync.start(), rule)
     this.scheduler_sync.mem.get(name).rule = rule
+
+    process.send({ state: 'ready:worker' })
   }
 
   async stopService () {


### PR DESCRIPTION
This PR fixes `process.send` for tests
The issue is that `Mocha` is done `process.spawn` (not `process.fork`) and in this case `process` is not contained `send` method