### PR TITLE
Add full tax report

### DIFF
--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -337,7 +337,7 @@ module.exports = new Map([
         'COMPLETED',
         null,
         null,
-        12345,
+        -12345,
         -0.012345,
         null,
         null,

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -47,7 +47,8 @@ const FullSnapshotReport = require('../sync/full.snapshot.report')
 const CurrencyConverter = require('../sync/currency.converter')
 const CsvJobData = require('../generate-csv/csv.job.data')
 const {
-  fullSnapshotReportCsvWriter
+  fullSnapshotReportCsvWriter,
+  fullTaxReportCsvWriter
 } = require('../generate-csv/csv-writer')
 const FullTaxReport = require('../sync/full.tax.report')
 
@@ -186,6 +187,13 @@ module.exports = ({
       .toConstantValue(
         bindDepsToFn(
           fullSnapshotReportCsvWriter,
+          [TYPES.RService]
+        )
+      )
+    bind(TYPES.FullTaxReportCsvWriter)
+      .toConstantValue(
+        bindDepsToFn(
+          fullTaxReportCsvWriter,
           [TYPES.RService]
         )
       )

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -49,6 +49,7 @@ const CsvJobData = require('../generate-csv/csv.job.data')
 const {
   fullSnapshotReportCsvWriter
 } = require('../generate-csv/csv-writer')
+const FullTaxReport = require('../sync/full.tax.report')
 
 decorate(injectable(), EventEmitter)
 
@@ -187,6 +188,8 @@ module.exports = ({
           [TYPES.RService]
         )
       )
+    bind(TYPES.FullTaxReport)
+      .to(FullTaxReport)
     rebind(TYPES.CsvJobData)
       .to(CsvJobData)
       .inSingletonScope()

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -73,7 +73,8 @@ module.exports = ({
           ['_balanceHistory', TYPES.BalanceHistory],
           ['_winLoss', TYPES.WinLoss],
           ['_positionsSnapshot', TYPES.PositionsSnapshot],
-          ['_fullSnapshotReport', TYPES.FullSnapshotReport]
+          ['_fullSnapshotReport', TYPES.FullSnapshotReport],
+          ['_fullTaxReport', TYPES.FullTaxReport]
         ]
       })
     rebind(TYPES.RServiceDepsSchemaAliase)

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -31,5 +31,6 @@ module.exports = {
   CurrencyConverter: Symbol.for('CurrencyConverter'),
   FullSnapshotReportCsvWriter: Symbol.for('FullSnapshotReportCsvWriter'),
   FOREX_SYMBS: Symbol.for('FOREX_SYMBS'),
-  FullTaxReport: Symbol.for('FullTaxReport')
+  FullTaxReport: Symbol.for('FullTaxReport'),
+  FullTaxReportCsvWriter: Symbol.for('FullTaxReportCsvWriter')
 }

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -30,5 +30,6 @@ module.exports = {
   FullSnapshotReport: Symbol.for('FullSnapshotReport'),
   CurrencyConverter: Symbol.for('CurrencyConverter'),
   FullSnapshotReportCsvWriter: Symbol.for('FullSnapshotReportCsvWriter'),
-  FOREX_SYMBS: Symbol.for('FOREX_SYMBS')
+  FOREX_SYMBS: Symbol.for('FOREX_SYMBS'),
+  FullTaxReport: Symbol.for('FullTaxReport')
 }

--- a/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
@@ -15,7 +15,8 @@ module.exports = (rService) => async (
   const {
     args: _args,
     columnsCsv,
-    formatSettings
+    formatSettings,
+    name
   } = { ...jobData }
   const { params: _params } = { ..._args }
   const params = {
@@ -78,7 +79,7 @@ module.exports = (rService) => async (
   walletsTickersStringifier.pipe(wStream)
 
   const res = await getDataFromApi(
-    rService.getFullSnapshotReport.bind(rService),
+    rService[name].bind(rService),
     args
   )
 

--- a/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
@@ -1,0 +1,195 @@
+'use strict'
+
+const { stringify } = require('csv')
+
+const {
+  write,
+  getDataFromApi
+} = require('bfx-report/workers/loc.api/queue/write-data-to-stream/helpers')
+
+module.exports = (rService) => async (
+  wStream,
+  jobData
+) => {
+  const queue = rService.ctx.lokue_aggregator.q
+  const {
+    args: _args,
+    columnsCsv,
+    formatSettings,
+    name
+  } = { ...jobData }
+  const { params: _params } = { ..._args }
+  const params = {
+    end: Date.now(),
+    ..._params
+  }
+  const args = { ..._args, params }
+
+  queue.emit('progress', 0)
+
+  if (typeof jobData === 'string') {
+    const stringifier = stringify(
+      { columns: ['mess'] }
+    )
+
+    stringifier.pipe(wStream)
+    write([{ mess: jobData }], stringifier)
+    queue.emit('progress', 100)
+    stringifier.end()
+
+    return
+  }
+
+  wStream.setMaxListeners(20)
+
+  const winLossTotalAmountStringifier = stringify({
+    header: true,
+    columns: columnsCsv.winLossTotalAmount
+  })
+  const startPosNameStringifier = stringify(
+    { columns: ['name'] }
+  )
+  const startPosStringifier = stringify({
+    header: true,
+    columns: columnsCsv.positionsSnapshot
+  })
+  const startTickersNameStringifier = stringify(
+    { columns: ['name'] }
+  )
+  const startTickersStringifier = stringify({
+    header: true,
+    columns: columnsCsv.tickers
+  })
+  const endPosNameStringifier = stringify(
+    { columns: ['name'] }
+  )
+  const endPosStringifier = stringify({
+    header: true,
+    columns: columnsCsv.positionsSnapshot
+  })
+  const endTickersNameStringifier = stringify(
+    { columns: ['name'] }
+  )
+  const endTickersStringifier = stringify({
+    header: true,
+    columns: columnsCsv.tickers
+  })
+  const movementsTotalAmountNameStringifier = stringify(
+    { columns: ['name'] }
+  )
+  const movementsTotalAmountStringifier = stringify({
+    header: true,
+    columns: columnsCsv.movementsTotalAmount
+  })
+  const movementsNameStringifier = stringify(
+    { columns: ['name'] }
+  )
+  const movementsStringifier = stringify({
+    header: true,
+    columns: columnsCsv.movements
+  })
+
+  winLossTotalAmountStringifier.pipe(wStream)
+  startPosNameStringifier.pipe(wStream)
+  startPosStringifier.pipe(wStream)
+  startTickersNameStringifier.pipe(wStream)
+  startTickersStringifier.pipe(wStream)
+  endPosNameStringifier.pipe(wStream)
+  endPosStringifier.pipe(wStream)
+  endTickersNameStringifier.pipe(wStream)
+  endTickersStringifier.pipe(wStream)
+  movementsTotalAmountNameStringifier.pipe(wStream)
+  movementsTotalAmountStringifier.pipe(wStream)
+  movementsNameStringifier.pipe(wStream)
+  movementsStringifier.pipe(wStream)
+
+  const res = await getDataFromApi(
+    rService[name].bind(rService),
+    args
+  )
+  const {
+    winLossTotalAmount,
+    startPositionsSnapshot,
+    startTickers,
+    endPositionsSnapshot,
+    endTickers,
+    depositsTotalAmount,
+    withdrawalsTotalAmount,
+    movementsTotalAmount,
+    movements
+  } = { ...res }
+
+  write(
+    [{ amount: winLossTotalAmount }, {}],
+    winLossTotalAmountStringifier,
+    formatSettings.winLossTotalAmount,
+    params
+  )
+
+  write([{ name: 'START POSITIONS' }], startPosNameStringifier)
+  write(
+    [...startPositionsSnapshot, {}],
+    startPosStringifier,
+    formatSettings.positionsSnapshot,
+    params
+  )
+  write([{ name: 'START TICKERS' }], startTickersNameStringifier)
+  write(
+    [...startTickers, {}],
+    startTickersStringifier,
+    formatSettings.tickers,
+    params
+  )
+  write([{ name: 'END POSITIONS' }], endPosNameStringifier)
+  write(
+    [...endPositionsSnapshot, {}],
+    endPosStringifier,
+    formatSettings.positionsSnapshot,
+    params
+  )
+  write([{ name: 'END TICKERS' }], endTickersNameStringifier)
+  write(
+    [...endTickers, {}],
+    endTickersStringifier,
+    formatSettings.tickers,
+    params
+  )
+
+  write([{ name: 'MOVEMENTS TOTAL AMOUNT' }], movementsTotalAmountNameStringifier)
+  write(
+    [
+      {
+        depositsTotalAmount,
+        withdrawalsTotalAmount,
+        movementsTotalAmount
+      },
+      {}
+    ],
+    movementsTotalAmountStringifier,
+    formatSettings.movementsTotalAmount,
+    params
+  )
+  write([{ name: 'MOVEMENTS DETAIL' }], movementsNameStringifier)
+  write(
+    movements,
+    movementsStringifier,
+    formatSettings.movements,
+    params
+  )
+
+  queue.emit('progress', 100)
+
+  winLossTotalAmountStringifier.end()
+  startPosNameStringifier.end()
+  startPosStringifier.end()
+  startTickersNameStringifier.end()
+  startTickersStringifier.end()
+  endPosNameStringifier.end()
+  endPosStringifier.end()
+  endTickersNameStringifier.end()
+  endTickersStringifier.end()
+  movementsTotalAmountNameStringifier.end()
+  movementsTotalAmountStringifier.end()
+  movementsNameStringifier.end()
+  movementsStringifier.end()
+}

--- a/workers/loc.api/generate-csv/csv-writer/index.js
+++ b/workers/loc.api/generate-csv/csv-writer/index.js
@@ -3,7 +3,11 @@
 const fullSnapshotReportCsvWriter = require(
   './full-snapshot-report-csv-writer'
 )
+const fullTaxReportCsvWriter = require(
+  './full-tax-report-csv-writer'
+)
 
 module.exports = {
-  fullSnapshotReportCsvWriter
+  fullSnapshotReportCsvWriter,
+  fullTaxReportCsvWriter
 }

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -21,11 +21,13 @@ const {
 class CsvJobData extends BaseCsvJobData {
   constructor (
     rService,
-    fullSnapshotReportCsvWriter
+    fullSnapshotReportCsvWriter,
+    fullTaxReportCsvWriter
   ) {
     super(rService)
 
     this.fullSnapshotReportCsvWriter = fullSnapshotReportCsvWriter
+    this.fullTaxReportCsvWriter = fullTaxReportCsvWriter
   }
 
   _addColumnsBySchema (columnsCsv = {}, schema = {}) {
@@ -299,9 +301,97 @@ class CsvJobData extends BaseCsvJobData {
 
     return jobData
   }
+
+  async getFullTaxReportCsvJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args, 'paramsSchemaForFullTaxReportCsv')
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      this.rService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(
+      args,
+      null,
+      { isOnMomentInName: true }
+    )
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getFullTaxReport',
+      fileNamesMap: [['getFullTaxReport', 'full-tax-report']],
+      args: csvArgs,
+      columnsCsv: {
+        winLossTotalAmount: {
+          amount: 'WIN/LOSS TOTAL AMOUNT USD'
+        },
+        movementsTotalAmount: {
+          depositsTotalAmount: 'DEPOSITS TOTAL AMOUNT USD',
+          withdrawalsTotalAmount: 'WITHDRAWALS TOTAL AMOUNT USD',
+          movementsTotalAmount: 'MOVEMENTS TOTAL AMOUNT USD'
+        },
+        movements: {
+          id: '#',
+          mtsUpdated: 'DATE',
+          currency: 'CURRENCY',
+          status: 'STATUS',
+          amount: 'AMOUNT',
+          fees: 'FEES',
+          destinationAddress: 'DESCRIPTION',
+          transactionId: 'TRANSACTION ID'
+        },
+        positionsSnapshot: {
+          id: '#',
+          symbol: 'PAIR',
+          amount: 'AMOUNT',
+          basePrice: 'BASE PRICE',
+          actualPrice: 'ACTUAL PRICE',
+          pl: 'P/L',
+          plUsd: 'P/L USD',
+          plPerc: 'P/L%',
+          marginFunding: 'FUNDING COST',
+          marginFundingType: 'FUNDING TYPE',
+          status: 'STATUS',
+          mtsUpdate: 'UPDATED',
+          mtsCreate: 'CREATED'
+        },
+        tickers: {
+          symbol: 'PAIR',
+          amount: 'AMOUNT'
+        }
+      },
+      formatSettings: {
+        movements: {
+          mtsUpdated: 'date'
+        },
+        positionsSnapshot: {
+          mtsUpdate: 'date',
+          mtsCreate: 'date',
+          symbol: 'symbol'
+        },
+        tickers: {
+          symbol: 'symbol'
+        }
+      },
+      csvCustomWriter: this.fullTaxReportCsvWriter
+    }
+
+    return jobData
+  }
 }
 
 decorate(inject(TYPES.RService), CsvJobData, 0)
 decorate(inject(TYPES.FullSnapshotReportCsvWriter), CsvJobData, 1)
+decorate(inject(TYPES.FullTaxReportCsvWriter), CsvJobData, 2)
 
 module.exports = CsvJobData

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -105,6 +105,26 @@ const paramsSchemaForFullSnapshotReportApi = {
   }
 }
 
+const paramsSchemaForFullTaxReportApi = {
+  type: 'object',
+  properties: {
+    timeframe: {
+      type: 'string',
+      enum: [
+        'day',
+        'month',
+        'year'
+      ]
+    },
+    end: {
+      type: 'integer'
+    },
+    start: {
+      type: 'integer'
+    }
+  }
+}
+
 const paramsSchemaForWinLossApi = {
   type: 'object',
   properties: {
@@ -186,6 +206,7 @@ module.exports = {
   paramsSchemaForWinLossApi,
   paramsSchemaForPositionsSnapshotApi,
   paramsSchemaForFullSnapshotReportApi,
+  paramsSchemaForFullTaxReportApi,
   paramsSchemaForRiskCsv,
   paramsSchemaForBalanceHistoryCsv,
   paramsSchemaForWinLossCsv,

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -199,6 +199,15 @@ const paramsSchemaForFullSnapshotReportCsv = {
   }
 }
 
+const paramsSchemaForFullTaxReportCsv = {
+  type: 'object',
+  properties: {
+    ...cloneDeep(paramsSchemaForFullTaxReportApi.properties),
+    timezone,
+    dateFormat
+  }
+}
+
 module.exports = {
   paramsSchemaForCandlesApi,
   paramsSchemaForRiskApi,
@@ -211,5 +220,6 @@ module.exports = {
   paramsSchemaForBalanceHistoryCsv,
   paramsSchemaForWinLossCsv,
   paramsSchemaForPositionsSnapshotCsv,
-  paramsSchemaForFullSnapshotReportCsv
+  paramsSchemaForFullSnapshotReportCsv,
+  paramsSchemaForFullTaxReportCsv
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -811,6 +811,18 @@ class FrameworkReportService extends ReportService {
     }, 'getFullSnapshotReport', cb)
   }
 
+  getFullTaxReport (space, args, cb) {
+    return this._responder(async () => {
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        throw new DuringSyncMethodAccessError()
+      }
+
+      checkParams(args, 'paramsSchemaForFullTaxReportApi')
+
+      return this._fullTaxReport.getFullTaxReport(args)
+    }, 'getFullTaxReport', cb)
+  }
+
   /**
    * @override
    */

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -870,6 +870,15 @@ class FrameworkReportService extends ReportService {
       )
     }, 'getFullSnapshotReportCsv', cb)
   }
+
+  getFullTaxReportCsv (space, args, cb) {
+    return this._responder(() => {
+      return this._generateCsv(
+        'getFullTaxReportCsvJobData',
+        args
+      )
+    }, 'getFullTaxReportCsv', cb)
+  }
 }
 
 module.exports = FrameworkReportService

--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -202,7 +202,6 @@ class FullTaxReport {
   async getFullTaxReport ({
     auth = {},
     params: {
-      timeframe = 'day',
       start = 0,
       end = Date.now()
     } = {}
@@ -212,7 +211,7 @@ class FullTaxReport {
     const args = {
       auth,
       params: {
-        timeframe,
+        timeframe: end,
         start,
         end
       }

--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -1,0 +1,187 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const TYPES = require('../../di/types')
+const {
+  getInsertableArrayObjectsFilter
+} = require('../dao/helpers')
+
+class FullTaxReport {
+  constructor (
+    dao,
+    syncSchema,
+    ALLOWED_COLLS,
+    winLoss,
+    positionsSnapshot
+  ) {
+    this.dao = dao
+    this.syncSchema = syncSchema
+    this.ALLOWED_COLLS = ALLOWED_COLLS
+    this.winLoss = winLoss
+    this.positionsSnapshot = positionsSnapshot
+  }
+
+  _getPositionsSnapshotAndTickers (args) {
+    const {
+      auth = {},
+      params = {}
+    } = { ...args }
+    const { mts: end = Date.now() } = { ...params }
+    const _args = {
+      auth,
+      params: {
+        end,
+        isCertainMoment: true
+      }
+    }
+
+    return this.positionsSnapshot
+      .getPositionsSnapshotAndTickers(_args)
+  }
+
+  // TODO:
+  _calcWinLossTotalAmount (winLoss) {
+    if (
+      !Array.isArray(winLoss) ||
+      winLoss.length === 0
+    ) {
+      return null
+    }
+  }
+
+  async _getMovements ({
+    user = {},
+    start = 0,
+    end = Date.now()
+  }) {
+    const movementsModel = this.syncSchema.getModelsMap()
+      .get(this.ALLOWED_COLLS.MOVEMENTS)
+    const movementsMethodColl = this.syncSchema.getMethodCollMap()
+      .get('_getMovements')
+
+    const movementsBaseFilter = getInsertableArrayObjectsFilter(
+      movementsMethodColl,
+      {
+        start,
+        end
+      }
+    )
+
+    const movements = await this.dao.getElemsInCollBy(
+      this.ALLOWED_COLLS.MOVEMENTS,
+      {
+        filter: {
+          ...movementsBaseFilter,
+          user_id: user._id
+        },
+        sort: [['mtsUpdated', -1]],
+        projection: movementsModel,
+        exclude: ['user_id'],
+        isExcludePrivate: true
+      }
+    )
+
+    if (!Array.isArray(movements)) {
+      return []
+    }
+
+    return movements
+  }
+
+  // TODO:
+  _calcMovementsTotalAmount (
+    movements,
+    {
+      isDeposits,
+      isWithdrawals
+    }
+  ) {
+    if (
+      !Array.isArray(movements) ||
+      movements.length === 0
+    ) {
+      return null
+    }
+  }
+
+  async getFullTaxReport ({
+    auth = {},
+    params: {
+      timeframe = 'day',
+      start = 0,
+      end = Date.now()
+    } = {}
+  } = {}) {
+    const user = await this.dao.checkAuthInDb({ auth })
+
+    const args = {
+      auth,
+      params: {
+        timeframe,
+        start,
+        end
+      }
+    }
+
+    const winLoss = await this.winLoss.getWinLoss(args)
+    const winLossTotalAmount = this._calcWinLossTotalAmount(winLoss)
+
+    const {
+      startPositionsSnapshot,
+      startTickers
+    } = await this._getPositionsSnapshotAndTickers({
+      auth,
+      params: { mts: start }
+    })
+    const {
+      endPositionsSnapshot,
+      endTickers
+    } = await this._getPositionsSnapshotAndTickers({
+      auth,
+      params: { mts: end }
+    })
+
+    const movements = await this._getMovements({
+      user,
+      start,
+      end
+    })
+    const movementsTotalAmount = this._calcMovementsTotalAmount(
+      movements
+    )
+    const depositsTotalAmount = this._calcMovementsTotalAmount(
+      movements,
+      { isDeposits: true }
+    )
+    const withdrawalsTotalAmount = this._calcMovementsTotalAmount(
+      movements,
+      { isWithdrawals: true }
+    )
+
+    return {
+      winLossTotalAmount,
+      startPositionsSnapshot,
+      startTickers,
+      endPositionsSnapshot,
+      endTickers,
+      movements,
+      movementsTotalAmount,
+      depositsTotalAmount,
+      withdrawalsTotalAmount
+    }
+  }
+}
+
+decorate(injectable(), FullTaxReport)
+decorate(inject(TYPES.DAO), FullTaxReport, 0)
+decorate(inject(TYPES.SyncSchema), FullTaxReport, 1)
+decorate(inject(TYPES.ALLOWED_COLLS), FullTaxReport, 2)
+decorate(inject(TYPES.WinLoss), FullTaxReport, 3)
+decorate(inject(TYPES.PositionsSnapshot), FullTaxReport, 4)
+
+module.exports = FullTaxReport

--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -37,10 +37,7 @@ class FullTaxReport {
     const { mts: end = Date.now() } = { ...params }
     const _args = {
       auth,
-      params: {
-        end,
-        isCertainMoment: true
-      }
+      params: { end }
     }
 
     return this.positionsSnapshot

--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -47,7 +47,6 @@ class FullTaxReport {
       .getPositionsSnapshotAndTickers(_args)
   }
 
-  // TODO:
   _calcWinLossTotalAmount (winLoss) {
     if (
       !Array.isArray(winLoss) ||
@@ -55,6 +54,35 @@ class FullTaxReport {
     ) {
       return null
     }
+
+    const res = winLoss.reduce((accum, item = {}) => {
+      const itemArr = Object.entries({ ...item })
+      const subRes = itemArr.reduce((subAccum, [symb, amount]) => {
+        const _subAccum = { ...accum, ...subAccum }
+
+        if (
+          !isForexSymb(symb) ||
+          !Number.isFinite(amount)
+        ) {
+          return _subAccum
+        }
+
+        return {
+          ..._subAccum,
+          [symb]: Number.isFinite(_subAccum[symb])
+            ? _subAccum[symb] + amount
+            : amount
+        }
+      }, {})
+
+      return {
+        ...accum,
+        ...subRes
+      }
+    }, {})
+    const { USD } = { ...res }
+
+    return USD
   }
 
   async _getMovements ({

--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -218,6 +218,7 @@ class FullTaxReport {
       }
     }
 
+    // TODO: need to change form timeframe to allPeriod (without calc)
     const winLoss = await this.winLoss.getWinLoss(args)
     const winLossTotalAmount = this._calcWinLossTotalAmount(winLoss)
 

--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -222,15 +222,15 @@ class FullTaxReport {
     const winLossTotalAmount = this._calcWinLossTotalAmount(winLoss)
 
     const {
-      startPositionsSnapshot,
-      startTickers
+      positionsSnapshot: startPositionsSnapshot,
+      tickers: startTickers
     } = await this._getPositionsSnapshotAndTickers({
       auth,
       params: { mts: start }
     })
     const {
-      endPositionsSnapshot,
-      endTickers
+      positionsSnapshot: endPositionsSnapshot,
+      tickers: endTickers
     } = await this._getPositionsSnapshotAndTickers({
       auth,
       params: { mts: end }

--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -217,7 +217,6 @@ class FullTaxReport {
       }
     }
 
-    // TODO: need to change form timeframe to allPeriod (without calc)
     const winLoss = await this.winLoss.getWinLoss(args)
     const winLossTotalAmount = this._calcWinLossTotalAmount(winLoss)
 


### PR DESCRIPTION
This PR adds full tax report, this includes the following:
  - total `win/loss` amount on the period in USD
  - `positions snapshot` of the start and `positions snapshot` of the end with the `tickers`
  - total amount of USD equivalent `movements` on the period
  - total amount of USD equivalent `Deposit/Withdrawal` on the period
  - detail of `Deposit/Withdrawal` on the period by currency