### PR TITLE
Add status messages report to sync mode

### DIFF
--- a/.mocha.opts
+++ b/.mocha.opts
@@ -1,3 +1,0 @@
---recursive test/**/*.spec.js
---timeout 10000
---exit

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "recursive": true,
+  "timeout": 10000,
+  "exit": true
+}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       }
     },
     "test": {
-      "command": "standard && mocha --opts .mocha.opts",
+      "command": "standard && mocha './test/**/*.spec.js' --config .mocharc.json",
       "env": {
         "NODE_ENV": "test"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "^4.2.0",
     "nodemon": "^1.18.10",
     "supertest": "^4.0.2",
-    "standard": "^12.0.1"
+    "standard": "^14.3.1"
   },
   "contributors": [
     "Paolo Ardoino <paolo@bitfinex.com>",

--- a/test/1-api-sync-mode-sqlite.spec.js
+++ b/test/1-api-sync-mode-sqlite.spec.js
@@ -544,6 +544,85 @@ describe('Sync mode API with SQLite', () => {
     assert.propertyVal(res.body.result[1], 'start', start)
   })
 
+  it('it should be successfully performed by the editStatusMessagesConf method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'editStatusMessagesConf',
+        params: [
+          {
+            start,
+            symbol: 'tBTCF0:USTF0'
+          }
+        ],
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isOk(res.body.result)
+  })
+
+  it('it should be successfully performed by the getSyncProgress method', async function () {
+    this.timeout(60000)
+
+    while (true) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send({
+          auth,
+          method: 'getSyncProgress',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isNumber(res.body.result)
+
+      if (
+        typeof res.body.result !== 'number' ||
+        res.body.result === 100
+      ) {
+        break
+      }
+
+      await delay()
+    }
+  })
+
+  it('it should be successfully performed by the getStatusMessagesConf method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getStatusMessagesConf',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.equal(res.body.result.length, 1)
+
+    assert.isObject(res.body.result[0])
+    assert.propertyVal(res.body.result[0], 'symbol', 'tBTCF0:USTF0')
+    assert.propertyVal(res.body.result[0], 'start', start)
+  })
+
   it('it should be successfully performed by the syncNow method', async function () {
     this.timeout(60000)
 
@@ -1475,6 +1554,43 @@ describe('Sync mode API with SQLite', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the getStatusMessages method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getStatusMessages',
+        params: {
+          symbol: 'tBTCF0:USTF0'
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isBoolean(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'key',
+      'timestamp',
+      'price',
+      'priceSpot',
+      'fundBal',
+      'fundingAccrued',
+      'fundingStep'
+    ])
+  })
+
   it('it should be successfully performed by the getOrderTrades method', async function () {
     this.timeout(5000)
 
@@ -2318,6 +2434,31 @@ describe('Sync mode API with SQLite', () => {
     assert.propertyVal(res.body.error, 'code', 500)
     assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
     assert.propertyVal(res.body, 'id', 5)
+  })
+
+  it('it should be successfully performed by the getStatusMessagesCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getStatusMessagesCsv',
+        params: {
+          symbol: ['tBTCF0:USTF0'],
+          timezone: 'America/Los_Angeles',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getOrderTradesCsv method', async function () {

--- a/test/1-api-sync-mode-sqlite.spec.js
+++ b/test/1-api-sync-mode-sqlite.spec.js
@@ -1725,7 +1725,7 @@ describe('Sync mode API with SQLite', () => {
     assert.isArray(res.body.result.res)
     assert.isNumber(res.body.result.nextPage)
 
-    let resItem = res.body.result.res[0]
+    const resItem = res.body.result.res[0]
 
     assert.isObject(resItem)
     assert.containsAllKeys(resItem, [

--- a/test/2-additional-api-sync-mode-sqlite.spec.js
+++ b/test/2-additional-api-sync-mode-sqlite.spec.js
@@ -196,7 +196,7 @@ describe('Additional sync mode API with SQLite', () => {
   })
 
   it('it should be successfully performed by the getWinLoss method', async function () {
-    this.timeout(5000)
+    this.timeout(10000)
 
     const timeframeArr = ['day', 'month', 'year']
     const paramsArr = Array(timeframeArr.length)

--- a/test/2-additional-api-sync-mode-sqlite.spec.js
+++ b/test/2-additional-api-sync-mode-sqlite.spec.js
@@ -353,7 +353,7 @@ describe('Additional sync mode API with SQLite', () => {
     this.timeout(10000)
 
     const paramsArr = [
-      { end },
+      { end, start },
       { end, start: end - (10 * 60 * 60 * 1000) }
     ]
 
@@ -374,24 +374,24 @@ describe('Additional sync mode API with SQLite', () => {
       assert.propertyVal(res.body, 'id', 5)
       assert.isObject(res.body.result)
 
-      assert.isNumber(res.body.result.winLossTotalAmount)
-      assert.isNumber(res.body.result.movementsTotalAmount)
-      assert.isNumber(res.body.result.depositsTotalAmount)
-      assert.isNumber(res.body.result.withdrawalsTotalAmount)
-      assert.isArray(res.body.result.startPositionsSnapshot)
-      assert.isArray(res.body.result.startTickers)
-      assert.isArray(res.body.result.endPositionsSnapshot)
-      assert.isArray(res.body.result.endTickers)
-      assert.isArray(res.body.result.movements)
+      assert.isArray(res.body.result.startingPositionsSnapshot)
+      assert.isArray(res.body.result.endingPositionsSnapshot)
+      assert.isObject(res.body.result.finalState)
+      assert.isObject(res.body.result.finalState.startingPeriodBalances)
+      assert.isArray(res.body.result.finalState.movements)
+      assert.isNumber(res.body.result.finalState.movementsTotalAmount)
+      assert.isObject(res.body.result.finalState.endingPeriodBalances)
+      assert.isNumber(res.body.result.finalState.totalResult)
 
       const positions = [
-        ...res.body.result.startPositionsSnapshot,
-        ...res.body.result.endPositionsSnapshot
+        ...res.body.result.startingPositionsSnapshot,
+        ...res.body.result.endingPositionsSnapshot
       ]
-      const tickers = [
-        ...res.body.result.startTickers,
-        ...res.body.result.endTickers
+      const periodsBalances = [
+        res.body.result.finalState.startingPeriodBalances,
+        res.body.result.finalState.endingPeriodBalances
       ]
+
       positions.forEach((item) => {
         assert.isObject(item)
         assert.containsAllKeys(item, [
@@ -410,14 +410,18 @@ describe('Additional sync mode API with SQLite', () => {
           'mtsUpdate'
         ])
       })
-      tickers.forEach((item) => {
-        assert.isObject(item)
-        assert.containsAllKeys(item, [
-          'symbol',
-          'amount'
-        ])
+      periodsBalances.forEach((item) => {
+        const {
+          walletsTotalBalanceUsd,
+          positionsTotalPlUsd,
+          totalResult
+        } = item
+
+        assert.isNumber(walletsTotalBalanceUsd)
+        assert.isNumber(positionsTotalPlUsd)
+        assert.isNumber(totalResult)
       })
-      res.body.result.movements.forEach((item) => {
+      res.body.result.finalState.movements.forEach((item) => {
         assert.isObject(item)
         assert.containsAllKeys(item, [
           'id',

--- a/test/3-api-filter-sync-mode-sqlite.spec.js
+++ b/test/3-api-filter-sync-mode-sqlite.spec.js
@@ -750,7 +750,6 @@ describe('API filter', () => {
       assert.propertyVal(res.body, 'id', 5)
       assert.isObject(res.body.result)
       assert.isArray(res.body.result.res)
-      // assert.isNumber(res.body.result.nextPage)
 
       responseTest(res.body.result.res)
     }
@@ -839,6 +838,37 @@ describe('API filter', () => {
       assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
       assert.propertyVal(res.body, 'id', 5)
     }
+  })
+
+  it('it should be successfully performed by the getLedgersCsv method', async function () {
+    this.timeout(20000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getLedgersCsv',
+        params: {
+          symbol: ['BTC'],
+          end,
+          start,
+          limit: 1000,
+          timezone: -3,
+          email,
+          filter: {
+            $gte: { id: 12345 }
+          }
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getMultipleCsv method', async function () {

--- a/test/3-api-filter-sync-mode-sqlite.spec.js
+++ b/test/3-api-filter-sync-mode-sqlite.spec.js
@@ -1,0 +1,893 @@
+'use strict'
+
+const path = require('path')
+const { assert } = require('chai')
+const request = require('supertest')
+
+const {
+  stopEnvironment
+} = require('bfx-report/test/helpers/helpers.boot')
+const {
+  rmDB,
+  rmAllFiles,
+  queueToPromise
+} = require('bfx-report/test/helpers/helpers.core')
+const {
+  testMethodOfGettingCsv
+} = require('bfx-report/test/helpers/helpers.tests')
+
+const {
+  startEnvironment
+} = require('./helpers/helpers.boot')
+const {
+  connToSQLite,
+  closeSQLite,
+  delay
+} = require('./helpers/helpers.core')
+const {
+  createMockRESTv2SrvWithDate
+} = require('./helpers/helpers.mock-rest-v2')
+
+process.env.NODE_CONFIG_DIR = path.join(__dirname, 'config')
+const { app } = require('bfx-report-express')
+const agent = request.agent(app)
+
+let wrkReportServiceApi = null
+let processorQueue = null
+let aggregatorQueue = null
+let mockRESTv2Srv = null
+let db = null
+
+const basePath = '/api'
+const tempDirPath = path.join(__dirname, '..', 'workers/loc.api/queue/temp')
+const dbDirPath = path.join(__dirname, '..', 'db')
+const date = new Date()
+const end = date.getTime()
+const start = (new Date()).setDate(date.getDate() - 90)
+const middle = (new Date()).setDate(date.getDate() - 45)
+const email = 'fake@email.fake'
+const auth = {
+  apiKey: 'fake',
+  apiSecret: 'fake'
+}
+
+describe('API filter', () => {
+  before(async function () {
+    this.timeout(5000)
+
+    mockRESTv2Srv = createMockRESTv2SrvWithDate(start, end, 10)
+
+    await rmAllFiles(tempDirPath, ['README.md'])
+    await rmDB(dbDirPath)
+    const env = await startEnvironment(false, false, 1, {
+      dbDriver: 'sqlite'
+    })
+
+    wrkReportServiceApi = env.wrksReportServiceApi[0]
+    processorQueue = wrkReportServiceApi.lokue_processor.q
+    aggregatorQueue = wrkReportServiceApi.lokue_aggregator.q
+
+    db = await connToSQLite()
+  })
+
+  after(async function () {
+    this.timeout(5000)
+
+    await stopEnvironment()
+    await closeSQLite(db)
+    await rmDB(dbDirPath)
+    await rmAllFiles(tempDirPath, ['README.md'])
+
+    try {
+      await mockRESTv2Srv.close()
+    } catch (err) { }
+  })
+
+  it('it should be successfully performed by the login method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'login',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isOk(res.body.result === email)
+  })
+
+  it('it should be successfully performed by the syncNow method', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'syncNow',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isOk(
+      typeof res.body.result === 'number' ||
+      res.body.result === 'SYNCHRONIZATION_IS_STARTED'
+    )
+  })
+
+  it('it should be successfully performed by the getSyncProgress method', async function () {
+    this.timeout(60000)
+
+    while (true) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send({
+          auth,
+          method: 'getSyncProgress',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isNumber(res.body.result)
+
+      if (
+        typeof res.body.result !== 'number' ||
+        res.body.result === 100
+      ) {
+        break
+      }
+
+      await delay()
+    }
+  })
+
+  it('it should be successfully performed by the editPublicTradesConf method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'editPublicTradesConf',
+        params: [
+          {
+            start,
+            symbol: 'tBTCUSD'
+          }
+        ],
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isOk(res.body.result)
+  })
+
+  it('it should be successfully performed by the getSyncProgress method', async function () {
+    this.timeout(60000)
+
+    while (true) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send({
+          auth,
+          method: 'getSyncProgress',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isNumber(res.body.result)
+
+      if (
+        typeof res.body.result !== 'number' ||
+        res.body.result === 100
+      ) {
+        break
+      }
+
+      await delay()
+    }
+  })
+
+  it('it should be successfully performed by the editTickersHistoryConf method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'editTickersHistoryConf',
+        params: [
+          {
+            start,
+            symbol: 'BTC'
+          }
+        ],
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isOk(res.body.result)
+  })
+
+  it('it should be successfully performed by the getSyncProgress method', async function () {
+    this.timeout(60000)
+
+    while (true) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send({
+          auth,
+          method: 'getSyncProgress',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isNumber(res.body.result)
+
+      if (
+        typeof res.body.result !== 'number' ||
+        res.body.result === 100
+      ) {
+        break
+      }
+
+      await delay()
+    }
+  })
+
+  it('it should be successfully performed by the api methods', async function () {
+    this.timeout(10000)
+
+    const baseArgs = {
+      auth,
+      id: 5
+    }
+    const baseParams = {
+      start: 0,
+      end,
+      limit: 10
+    }
+    const argsArr = [
+      {
+        args: {
+          ...baseArgs,
+          method: 'getTickersHistory',
+          params: {
+            ...baseParams,
+            symbol: 'BTC',
+            filter: {
+              $lt: { mtsUpdate: middle }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'symbol',
+              'bid',
+              'bidPeriod',
+              'ask',
+              'mtsUpdate'
+            ])
+            assert(Number.isInteger(item.mtsUpdate))
+            assert.isBelow(item.mtsUpdate, middle)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getPositionsHistory',
+          params: {
+            ...baseParams,
+            symbol: 'tBTCUSD',
+            filter: {
+              $gte: { id: 12347 }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'symbol',
+              'status',
+              'amount',
+              'basePrice',
+              'marginFunding',
+              'marginFundingType',
+              'pl',
+              'plPerc',
+              'liquidationPrice',
+              'leverage',
+              'placeholder',
+              'id',
+              'mtsCreate',
+              'mtsUpdate'
+            ])
+            assert(Number.isInteger(item.id))
+            assert.isAtLeast(item.id, 12347)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getPositionsAudit',
+          params: {
+            ...baseParams,
+            id: [12345, 12346, 12347],
+            symbol: 'tBTCUSD',
+            filter: {
+              $lte: { id: 12346 }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'symbol',
+              'status',
+              'amount',
+              'basePrice',
+              'marginFunding',
+              'marginFundingType',
+              'pl',
+              'plPerc',
+              'liquidationPrice',
+              'leverage',
+              'placeholder',
+              'id',
+              'mtsCreate',
+              'mtsUpdate',
+              'collateral',
+              'collateralMin',
+              'meta'
+            ])
+            assert(Number.isInteger(item.id))
+            assert.isAtMost(item.id, 12346)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getLedgers',
+          params: {
+            ...baseParams,
+            symbol: 'BTC',
+            filter: {
+              $gt: { id: 12346 }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'id',
+              'currency',
+              'mts',
+              'amount',
+              'balance',
+              'description',
+              'wallet'
+            ])
+            assert(Number.isInteger(item.id))
+            assert.isAbove(item.id, 12346)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getTrades',
+          params: {
+            ...baseParams,
+            symbol: 'tBTCUSD',
+            filter: {
+              $eq: { id: 12345 }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'id',
+              'symbol',
+              'mtsCreate',
+              'orderID',
+              'execAmount',
+              'execPrice',
+              'orderType',
+              'orderPrice',
+              'maker',
+              'fee',
+              'feeCurrency'
+            ])
+            assert(Number.isInteger(item.id))
+            assert.equal(item.id, 12345)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getFundingTrades',
+          params: {
+            ...baseParams,
+            symbol: 'fBTC',
+            filter: {
+              $ne: { id: 12346 }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'id',
+              'symbol',
+              'mtsCreate',
+              'offerID',
+              'amount',
+              'rate',
+              'period',
+              'maker'
+            ])
+            assert(Number.isInteger(item.id))
+            assert.notEqual(item.id, 12346)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getPublicTrades',
+          params: {
+            ...baseParams,
+            symbol: 'tBTCUSD',
+            filter: {
+              $not: { id: 12346 }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'id',
+              'mts',
+              'amount',
+              'price'
+            ])
+            assert(Number.isInteger(item.id))
+            assert.notEqual(item.id, 12346)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getOrderTrades',
+          params: {
+            ...baseParams,
+            id: 12345,
+            symbol: 'tBTCUSD',
+            filter: {
+              $like: { symbol: 'tBTC%' }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'id',
+              'symbol',
+              'mtsCreate',
+              'orderID',
+              'execAmount',
+              'execPrice',
+              'orderType',
+              'orderPrice',
+              'maker',
+              'fee',
+              'feeCurrency'
+            ])
+            assert.isString(item.symbol)
+            assert.match(item.symbol, /^tBTC/)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getOrders',
+          params: {
+            ...baseParams,
+            symbol: 'tBTCUSD',
+            filter: {
+              $like: { symbol: 'tETH%' }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.lengthOf(res, 0)
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getMovements',
+          params: {
+            ...baseParams,
+            symbol: 'BTC',
+            filter: {
+              $in: { id: [12345, 12346, 12347] }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'id',
+              'currency',
+              'currencyName',
+              'mtsStarted',
+              'mtsUpdated',
+              'status',
+              'amount',
+              'fees',
+              'destinationAddress',
+              'transactionId'
+            ])
+            assert(Number.isInteger(item.id))
+            assert.include([12345, 12346, 12347], item.id)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getFundingOfferHistory',
+          params: {
+            ...baseParams,
+            symbol: 'fUSD',
+            filter: {
+              $nin: { id: [12345, 12346, 12347] }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'id',
+              'symbol',
+              'mtsCreate',
+              'mtsUpdate',
+              'amount',
+              'amountOrig',
+              'type',
+              'flags',
+              'status',
+              'rate',
+              'period',
+              'notify',
+              'hidden',
+              'renew',
+              'rateReal',
+              'amountExecuted'
+            ])
+            assert(Number.isInteger(item.id))
+            assert.notInclude([12345, 12346, 12347], item.id)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getFundingLoanHistory',
+          params: {
+            ...baseParams,
+            symbol: 'fUSD',
+            filter: {
+              $nin: { id: [12345, 12346, 12347] }
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'id',
+              'symbol',
+              'side',
+              'mtsCreate',
+              'mtsUpdate',
+              'amount',
+              'flags',
+              'status',
+              'rate',
+              'period',
+              'mtsOpening',
+              'mtsLastPayout',
+              'notify',
+              'hidden',
+              'renew',
+              'rateReal',
+              'noClose'
+            ])
+            assert(Number.isInteger(item.id))
+            assert.notInclude([12345, 12346, 12347], item.id)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getFundingCreditHistory',
+          params: {
+            ...baseParams,
+            symbol: 'fUSD',
+            filter: {
+              $isNull: ['flags']
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.isAbove(res.length, 0)
+
+          res.forEach((item) => {
+            assert.isObject(item)
+            assert.containsAllKeys(item, [
+              'id',
+              'symbol',
+              'side',
+              'mtsCreate',
+              'mtsUpdate',
+              'amount',
+              'flags',
+              'status',
+              'rate',
+              'period',
+              'mtsOpening',
+              'mtsLastPayout',
+              'notify',
+              'hidden',
+              'renew',
+              'rateReal',
+              'noClose',
+              'positionPair'
+            ])
+            assert.isNull(item.flags)
+          })
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getFundingCreditHistory',
+          params: {
+            ...baseParams,
+            symbol: 'fUSD',
+            filter: {
+              $isNotNull: ['flags']
+            }
+          }
+        },
+        responseTest: (res) => {
+          assert.lengthOf(res, 0)
+        }
+      }
+    ]
+
+    for (const { args, responseTest } of argsArr) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send(args)
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isObject(res.body.result)
+      assert.isArray(res.body.result.res)
+      // assert.isNumber(res.body.result.nextPage)
+
+      responseTest(res.body.result.res)
+    }
+  })
+
+  it('it should not be successfully performed by the api methods', async function () {
+    this.timeout(60000)
+
+    const baseArgs = {
+      auth,
+      id: 5
+    }
+    const baseParams = {
+      start,
+      end,
+      limit: 1000,
+      timezone: -3,
+      email
+    }
+    const argsArr = [
+      {
+        args: {
+          ...baseArgs,
+          method: 'getLedgersCsv',
+          params: {
+            ...baseParams,
+            symbol: ['BTC'],
+            filter: {
+              $gte: { someFakeField: 12345 }
+            }
+          }
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getLedgersCsv',
+          params: {
+            ...baseParams,
+            symbol: ['BTC'],
+            filter: {
+              $gte: '12345'
+            }
+          }
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getLedgersCsv',
+          params: {
+            ...baseParams,
+            symbol: ['BTC'],
+            filter: {
+              $gte: { id: '12345' }
+            }
+          }
+        }
+      },
+      {
+        args: {
+          ...baseArgs,
+          method: 'getTradesCsv',
+          params: {
+            ...baseParams,
+            symbol: ['tBTCUSD', 'tETHUSD'],
+            filter: {
+              $someCond: { id: 12345 }
+            }
+          }
+        }
+      }
+    ]
+
+    for (const { args } of argsArr) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send(args)
+        .expect('Content-Type', /json/)
+        .expect(500)
+
+      assert.isObject(res.body)
+      assert.isObject(res.body.error)
+      assert.propertyVal(res.body.error, 'code', 500)
+      assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+      assert.propertyVal(res.body, 'id', 5)
+    }
+  })
+
+  it('it should be successfully performed by the getMultipleCsv method', async function () {
+    this.timeout(20000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMultipleCsv',
+        params: {
+          email,
+          language: 'ru',
+          multiExport: [
+            {
+              method: 'getTradesCsv',
+              symbol: ['tBTCUSD', 'tETHUSD'],
+              end,
+              start,
+              limit: 1000,
+              timezone: 'America/Los_Angeles',
+              filter: {
+                $or: {
+                  $eq: { id: 12346 },
+                  $lt: { mtsCreate: middle }
+                }
+              }
+            },
+            {
+              method: 'getTickersHistoryCsv',
+              symbol: 'BTC',
+              end,
+              start,
+              limit: 1000,
+              filter: {
+                $gte: { mtsUpdate: middle }
+              }
+            }
+          ]
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+})

--- a/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
@@ -42,44 +42,29 @@ module.exports = (rService) => async (
 
   wStream.setMaxListeners(20)
 
-  const winLossTotalAmountStringifier = stringify({
-    header: true,
-    columns: columnsCsv.winLossTotalAmount
-  })
-  const startPosNameStringifier = stringify(
+  const startingPositionsSnapshotNameStringifier = stringify(
     { columns: ['name'] }
   )
-  const startPosStringifier = stringify({
+  const startingPositionsSnapshotStringifier = stringify({
     header: true,
     columns: columnsCsv.positionsSnapshot
   })
-  const startTickersNameStringifier = stringify(
+  const endingPositionsSnapshotNameStringifier = stringify(
     { columns: ['name'] }
   )
-  const startTickersStringifier = stringify({
-    header: true,
-    columns: columnsCsv.tickers
-  })
-  const endPosNameStringifier = stringify(
-    { columns: ['name'] }
-  )
-  const endPosStringifier = stringify({
+  const endingPositionsSnapshotStringifier = stringify({
     header: true,
     columns: columnsCsv.positionsSnapshot
   })
-  const endTickersNameStringifier = stringify(
+  const finalStateNameStringifier = stringify(
     { columns: ['name'] }
   )
-  const endTickersStringifier = stringify({
-    header: true,
-    columns: columnsCsv.tickers
-  })
-  const movementsTotalAmountNameStringifier = stringify(
+  const startingPeriodBalancesNameStringifier = stringify(
     { columns: ['name'] }
   )
-  const movementsTotalAmountStringifier = stringify({
+  const startingPeriodBalancesStringifier = stringify({
     header: true,
-    columns: columnsCsv.movementsTotalAmount
+    columns: columnsCsv.periodBalances
   })
   const movementsNameStringifier = stringify(
     { columns: ['name'] }
@@ -88,108 +73,126 @@ module.exports = (rService) => async (
     header: true,
     columns: columnsCsv.movements
   })
+  const movementsTotalAmountStringifier = stringify({
+    header: true,
+    columns: columnsCsv.movementsTotalAmount
+  })
+  const endingPeriodBalancesNameStringifier = stringify(
+    { columns: ['name'] }
+  )
+  const endingPeriodBalancesStringifier = stringify({
+    header: true,
+    columns: columnsCsv.periodBalances
+  })
+  const totalResultStringifier = stringify({
+    header: true,
+    columns: columnsCsv.totalResult
+  })
 
-  winLossTotalAmountStringifier.pipe(wStream)
-  startPosNameStringifier.pipe(wStream)
-  startPosStringifier.pipe(wStream)
-  startTickersNameStringifier.pipe(wStream)
-  startTickersStringifier.pipe(wStream)
-  endPosNameStringifier.pipe(wStream)
-  endPosStringifier.pipe(wStream)
-  endTickersNameStringifier.pipe(wStream)
-  endTickersStringifier.pipe(wStream)
-  movementsTotalAmountNameStringifier.pipe(wStream)
-  movementsTotalAmountStringifier.pipe(wStream)
+  startingPositionsSnapshotNameStringifier.pipe(wStream)
+  startingPositionsSnapshotStringifier.pipe(wStream)
+  endingPositionsSnapshotNameStringifier.pipe(wStream)
+  endingPositionsSnapshotStringifier.pipe(wStream)
+  finalStateNameStringifier.pipe(wStream)
+  startingPeriodBalancesNameStringifier.pipe(wStream)
+  startingPeriodBalancesStringifier.pipe(wStream)
   movementsNameStringifier.pipe(wStream)
   movementsStringifier.pipe(wStream)
+  movementsTotalAmountStringifier.pipe(wStream)
+  endingPeriodBalancesNameStringifier.pipe(wStream)
+  endingPeriodBalancesStringifier.pipe(wStream)
+  totalResultStringifier.pipe(wStream)
 
   const res = await getDataFromApi(
     rService[name].bind(rService),
     args
   )
   const {
-    winLossTotalAmount,
-    startPositionsSnapshot,
-    startTickers,
-    endPositionsSnapshot,
-    endTickers,
-    depositsTotalAmount,
-    withdrawalsTotalAmount,
-    movementsTotalAmount,
-    movements
+    startingPositionsSnapshot,
+    endingPositionsSnapshot,
+    finalState: {
+      startingPeriodBalances,
+      movements,
+      movementsTotalAmount,
+      endingPeriodBalances,
+      totalResult
+    }
   } = { ...res }
 
   write(
-    [{ amount: winLossTotalAmount }, {}],
-    winLossTotalAmountStringifier,
-    formatSettings.winLossTotalAmount,
-    params
+    [{ name: 'STARTING POSITIONS SNAPSHOT' }],
+    startingPositionsSnapshotNameStringifier
   )
-
-  write([{ name: 'START POSITIONS' }], startPosNameStringifier)
   write(
-    [...startPositionsSnapshot, {}],
-    startPosStringifier,
+    [...startingPositionsSnapshot, {}],
+    startingPositionsSnapshotStringifier,
     formatSettings.positionsSnapshot,
     params
   )
-  write([{ name: 'START TICKERS' }], startTickersNameStringifier)
+
   write(
-    [...startTickers, {}],
-    startTickersStringifier,
-    formatSettings.tickers,
-    params
+    [{ name: 'ENDING POSITIONS SNAPSHOT' }],
+    endingPositionsSnapshotNameStringifier
   )
-  write([{ name: 'END POSITIONS' }], endPosNameStringifier)
   write(
-    [...endPositionsSnapshot, {}],
-    endPosStringifier,
+    [...endingPositionsSnapshot, {}],
+    endingPositionsSnapshotStringifier,
     formatSettings.positionsSnapshot,
     params
   )
-  write([{ name: 'END TICKERS' }], endTickersNameStringifier)
-  write(
-    [...endTickers, {}],
-    endTickersStringifier,
-    formatSettings.tickers,
-    params
-  )
 
-  write([{ name: 'MOVEMENTS TOTAL AMOUNT' }], movementsTotalAmountNameStringifier)
   write(
-    [
-      {
-        depositsTotalAmount,
-        withdrawalsTotalAmount,
-        movementsTotalAmount
-      },
-      {}
-    ],
-    movementsTotalAmountStringifier,
-    formatSettings.movementsTotalAmount,
-    params
+    [{ name: 'FINAL STATE' }],
+    finalStateNameStringifier
   )
-  write([{ name: 'MOVEMENTS DETAIL' }], movementsNameStringifier)
   write(
-    movements,
+    [{ name: 'STARTING PERIOD BALANCES' }],
+    startingPeriodBalancesNameStringifier
+  )
+  write(
+    [startingPeriodBalances, {}],
+    startingPeriodBalancesStringifier
+  )
+  write(
+    [{ name: 'MOVEMENTS DETAIL' }],
+    movementsNameStringifier
+  )
+  write(
+    [...movements, {}],
     movementsStringifier,
     formatSettings.movements,
     params
   )
+  write(
+    [{ movementsTotalAmount }, {}],
+    movementsTotalAmountStringifier
+  )
+  write(
+    [{ name: 'ENDING PERIOD BALANCES' }],
+    endingPeriodBalancesNameStringifier
+  )
+  write(
+    [endingPeriodBalances, {}],
+    endingPeriodBalancesStringifier
+  )
+  write(
+    [{ totalResult }],
+    totalResultStringifier
+  )
 
   queue.emit('progress', 100)
 
-  winLossTotalAmountStringifier.end()
-  startPosNameStringifier.end()
-  startPosStringifier.end()
-  startTickersNameStringifier.end()
-  startTickersStringifier.end()
-  endPosNameStringifier.end()
-  endPosStringifier.end()
-  endTickersNameStringifier.end()
-  endTickersStringifier.end()
-  movementsTotalAmountNameStringifier.end()
-  movementsTotalAmountStringifier.end()
+  startingPositionsSnapshotNameStringifier.end()
+  startingPositionsSnapshotStringifier.end()
+  endingPositionsSnapshotNameStringifier.end()
+  endingPositionsSnapshotStringifier.end()
+  finalStateNameStringifier.end()
+  startingPeriodBalancesNameStringifier.end()
+  startingPeriodBalancesStringifier.end()
   movementsNameStringifier.end()
   movementsStringifier.end()
+  movementsTotalAmountStringifier.end()
+  endingPeriodBalancesNameStringifier.end()
+  endingPeriodBalancesStringifier.end()
+  totalResultStringifier.end()
 }

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -338,24 +338,6 @@ class CsvJobData extends BaseCsvJobData {
       fileNamesMap: [['getFullTaxReport', 'full-tax-report']],
       args: csvArgs,
       columnsCsv: {
-        winLossTotalAmount: {
-          amount: 'WIN/LOSS TOTAL AMOUNT USD'
-        },
-        movementsTotalAmount: {
-          depositsTotalAmount: 'DEPOSITS TOTAL AMOUNT USD',
-          withdrawalsTotalAmount: 'WITHDRAWALS TOTAL AMOUNT USD',
-          movementsTotalAmount: 'MOVEMENTS TOTAL AMOUNT USD'
-        },
-        movements: {
-          id: '#',
-          mtsUpdated: 'DATE',
-          currency: 'CURRENCY',
-          status: 'STATUS',
-          amount: 'AMOUNT',
-          fees: 'FEES',
-          destinationAddress: 'DESCRIPTION',
-          transactionId: 'TRANSACTION ID'
-        },
         positionsSnapshot: {
           id: '#',
           symbol: 'PAIR',
@@ -371,22 +353,36 @@ class CsvJobData extends BaseCsvJobData {
           mtsUpdate: 'UPDATED',
           mtsCreate: 'CREATED'
         },
-        tickers: {
-          symbol: 'PAIR',
-          amount: 'AMOUNT'
+        movements: {
+          id: '#',
+          mtsUpdated: 'DATE',
+          currency: 'CURRENCY',
+          status: 'STATUS',
+          amount: 'AMOUNT',
+          fees: 'FEES',
+          destinationAddress: 'DESCRIPTION',
+          transactionId: 'TRANSACTION ID'
+        },
+        periodBalances: {
+          walletsTotalBalanceUsd: 'WALLETS TOTAL BALANCE USD',
+          positionsTotalPlUsd: 'POSITIONS TOTAL P/L USD',
+          totalResult: 'TOTAL RESULT USD'
+        },
+        movementsTotalAmount: {
+          movementsTotalAmount: 'MOVEMENTS TOTAL AMOUNT USD'
+        },
+        totalResult: {
+          totalResult: 'TOTAL RESULT USD'
         }
       },
       formatSettings: {
-        movements: {
-          mtsUpdated: 'date'
-        },
         positionsSnapshot: {
           mtsUpdate: 'date',
           mtsCreate: 'date',
           symbol: 'symbol'
         },
-        tickers: {
-          symbol: 'symbol'
+        movements: {
+          mtsUpdated: 'date'
         }
       },
       csvCustomWriter: this.fullTaxReportCsvWriter

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -633,7 +633,6 @@ class FrameworkReportService extends ReportService {
             : symbol
         }
       }
-      console.log('[preparedArgs]:'.bgGreen, preparedArgs)
 
       const confs = await this._publicСollsСonfAccessors
         .getPublicСollsСonf(
@@ -647,7 +646,6 @@ class FrameworkReportService extends ReportService {
 
       const _args = this._publicСollsСonfAccessors
         .getArgs(confs, preparedArgs)
-      console.log('[_args]:'.bgBlue, _args)
 
       return this._dao.findInCollBy(
         '_getStatusMessages',

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -604,6 +604,42 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
+   * TODO:
+   * @override
+   */
+  getStatusMessages (space, args, cb) {
+    return this._responder(async () => {
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        return super.getStatusMessages(space, args)
+      }
+
+      checkParams(args, 'paramsSchemaForStatusMessagesApi')
+
+      const confs = await this._publicСollsСonfAccessors
+        .getPublicСollsСonf(
+          'statusMessagesConf',
+          args
+        )
+
+      if (isEmpty(confs)) {
+        return emptyRes()
+      }
+
+      const _args = this._publicСollsСonfAccessors
+        .getArgs(confs, args)
+
+      return this._dao.findInCollBy(
+        '_getStatusMessages',
+        _args,
+        {
+          isPrepareResponse: true,
+          isPublic: true
+        }
+      )
+    }, 'getStatusMessages', cb)
+  }
+
+  /**
    * @override
    */
   getOrderTrades (space, args, cb) {

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -612,10 +612,33 @@ class FrameworkReportService extends ReportService {
 
       checkParams(args, 'paramsSchemaForStatusMessagesApi')
 
+      const { params } = { ...args }
+      const {
+        type = 'deriv',
+        symbol = ['ALL']
+      } = { ...params }
+      const preparedArgs = {
+        ...args,
+        params: {
+          ...params,
+          type,
+          symbol: (
+            symbol === 'ALL' ||
+            (
+              Array.isArray(symbol) &&
+              symbol[0] === 'ALL'
+            )
+          )
+            ? null
+            : symbol
+        }
+      }
+      console.log('[preparedArgs]:'.bgGreen, preparedArgs)
+
       const confs = await this._publicСollsСonfAccessors
         .getPublicСollsСonf(
           'statusMessagesConf',
-          args
+          preparedArgs
         )
 
       if (isEmpty(confs)) {
@@ -623,7 +646,8 @@ class FrameworkReportService extends ReportService {
       }
 
       const _args = this._publicСollsСonfAccessors
-        .getArgs(confs, args)
+        .getArgs(confs, preparedArgs)
+      console.log('[_args]:'.bgBlue, _args)
 
       return this._dao.findInCollBy(
         '_getStatusMessages',

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -423,6 +423,7 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
+   * TODO:
    * @override
    */
   getTickersHistory (space, args, cb) {
@@ -443,44 +444,12 @@ class FrameworkReportService extends ReportService {
         return emptyRes()
       }
 
-      const _symb = args.params.symbol
-        ? [args.params.symbol]
-        : []
-      const symbols = Array.isArray(args.params.symbol)
-        ? args.params.symbol
-        : _symb
-      const filteredSymbols = symbols.filter(symb => {
-        return confs.some(conf => symb === conf.symbol)
-      })
-
-      if (
-        !isEmpty(symbols) &&
-        isEmpty(filteredSymbols)
-      ) {
-        return emptyRes()
-      }
-
-      args.params.symbol = filteredSymbols
-
-      const minConfStart = confs.reduce(
-        (accum, conf) => {
-          return (accum === null || conf.start < accum)
-            ? conf.start
-            : accum
-        },
-        null
-      )
-
-      if (
-        Number.isFinite(args.params.start) &&
-        args.params.start < minConfStart
-      ) {
-        args.params.start = minConfStart
-      }
+      const _args = this._publicСollsСonfAccessors
+        .getArgs(confs, args)
 
       return this._dao.findInCollBy(
         '_getTickersHistory',
-        args,
+        _args,
         {
           isPrepareResponse: true,
           isPublic: true
@@ -580,6 +549,7 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
+   * TODO:
    * @override
    */
   getPublicTrades (space, args, cb) {
@@ -590,34 +560,22 @@ class FrameworkReportService extends ReportService {
 
       checkParams(args, 'paramsSchemaForPublicTrades', ['symbol'])
 
-      const symbol = Array.isArray(args.params.symbol)
-        ? args.params.symbol[0]
-        : args.params.symbol
-      const { _id } = await this._dao.checkAuthInDb(args)
-      const conf = await this._dao.getElemInCollBy(
-        'publicСollsСonf',
-        {
-          confName: 'publicTradesConf',
-          user_id: _id,
-          symbol
-        },
-        [['symbol', 1]]
-      )
+      const confs = await this._publicСollsСonfAccessors
+        .getPublicСollsСonf(
+          'tickersHistoryConf',
+          args
+        )
 
-      if (isEmpty(conf)) {
+      if (isEmpty(confs)) {
         return emptyRes()
       }
 
-      if (
-        Number.isFinite(args.params.start) &&
-        args.params.start < conf.start
-      ) {
-        args.params.start = conf.start
-      }
+      const _args = this._publicСollsСonfAccessors
+        .getArgs(confs, args)
 
       return this._dao.findInCollBy(
         '_getPublicTrades',
-        args,
+        _args,
         {
           isPrepareResponse: true,
           isPublic: true

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -316,6 +316,13 @@ class FrameworkReportService extends ReportService {
     }, 'getTickersHistoryConf', cb)
   }
 
+  getStatusMessagesConf (space, args = {}, cb) {
+    return this._responder(() => {
+      return this._publicСollsСonfAccessors
+        .getPublicСollsСonf('statusMessagesConf', args)
+    }, 'getStatusMessagesConf', cb)
+  }
+
   editPublicTradesConf (space, args = {}, cb) {
     return this._responder(async () => {
       checkParams(args, 'paramsSchemaForEditPublicСollsСonf')
@@ -338,6 +345,18 @@ class FrameworkReportService extends ReportService {
 
       return true
     }, 'editTickersHistoryConf', cb)
+  }
+
+  editStatusMessagesConf (space, args = {}, cb) {
+    return this._responder(async () => {
+      checkParams(args, 'paramsSchemaForEditPublicСollsСonf')
+
+      await this._publicСollsСonfAccessors
+        .editPublicСollsСonf('statusMessagesConf', args)
+      await this._sync.start(true, this._ALLOWED_COLLS.STATUS_MESSAGES)
+
+      return true
+    }, 'editStatusMessagesConf', cb)
   }
 
   /**

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -442,7 +442,6 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
-   * TODO:
    * @override
    */
   getTickersHistory (space, args, cb) {
@@ -568,7 +567,6 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
-   * TODO:
    * @override
    */
   getPublicTrades (space, args, cb) {
@@ -581,7 +579,7 @@ class FrameworkReportService extends ReportService {
 
       const confs = await this._publicСollsСonfAccessors
         .getPublicСollsСonf(
-          'tickersHistoryConf',
+          'publicTradesConf',
           args
         )
 
@@ -604,7 +602,6 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
-   * TODO:
    * @override
    */
   getStatusMessages (space, args, cb) {

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -38,6 +38,10 @@ class ReportService extends BaseReportService {
     return super.getPublicTrades(null, args)
   }
 
+  _getStatusMessages (args) {
+    return super.getStatusMessages(null, args)
+  }
+
   _getOrders (args) {
     return super.getOrders(null, args)
   }

--- a/workers/loc.api/sync/allowed.colls.js
+++ b/workers/loc.api/sync/allowed.colls.js
@@ -18,5 +18,6 @@ module.exports = {
   SYMBOLS: 'symbols',
   FUTURES: 'futures',
   CURRENCIES: 'currencies',
-  CANDLES: 'candles'
+  CANDLES: 'candles',
+  STATUS_MESSAGES: 'statusMessages'
 }

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -146,24 +146,20 @@ class PublicСollsСonfAccessors {
       : start
   }
 
-  getSymbol (confs, symbol) {
-    const isSymbolArr = Array.isArray(symbol)
+  getSymbol (confs) {
     const _confs = Array.isArray(confs)
       ? confs
       : [confs]
     const confsSymbols = _confs.map(({ symbol }) => symbol)
 
-    return isSymbolArr
-      ? confsSymbols
-      : confsSymbols[0]
+    return confsSymbols
   }
 
   getArgs (confs, args) {
     const { params } = { ...args }
 
     const symbol = this.getSymbol(
-      confs,
-      params.symbol
+      confs
     )
     const start = this.getStart(
       confs,

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pick } = require('lodash')
+const { pick, isEmpty } = require('lodash')
 const {
   decorate,
   injectable,
@@ -103,13 +103,20 @@ class PublicСollsСonfAccessors {
 
   async getPublicСollsСonf (confName, args) {
     const { _id } = await this.dao.checkAuthInDb(args)
+    const { params } = { ...args }
+    const { symbol } = { ...params }
+    const baseFilter = {
+      confName,
+      user_id: _id
+    }
+    const filter = isEmpty(symbol)
+      ? baseFilter
+      : { ...baseFilter, symbol }
+
     const conf = await this.dao.getElemsInCollBy(
       'publicСollsСonf',
       {
-        filter: {
-          confName,
-          user_id: _id
-        },
+        filter,
         sort: [['symbol', 1]]
       }
     )

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -124,6 +124,61 @@ class PublicСollsСonfAccessors {
 
     return res
   }
+
+  getStart (confs, start = 0) {
+    const _confs = Array.isArray(confs)
+      ? confs
+      : [confs]
+    const minConfStart = _confs.reduce(
+      (accum, conf) => {
+        return (accum === null || conf.start < accum)
+          ? conf.start
+          : accum
+      },
+      null
+    )
+
+    return (
+      Number.isFinite(start) &&
+      start < minConfStart
+    )
+      ? minConfStart
+      : start
+  }
+
+  getSymbol (confs, symbol) {
+    const isSymbolArr = Array.isArray(symbol)
+    const _confs = Array.isArray(confs)
+      ? confs
+      : [confs]
+    const confsSymbols = _confs.map(({ symbol }) => symbol)
+
+    return isSymbolArr
+      ? confsSymbols
+      : confsSymbols[0]
+  }
+
+  getArgs (confs, args) {
+    const { params } = { ...args }
+
+    const symbol = this.getSymbol(
+      confs,
+      params.symbol
+    )
+    const start = this.getStart(
+      confs,
+      params.start
+    )
+
+    return {
+      ...args,
+      params: {
+        ...params,
+        symbol,
+        start
+      }
+    }
+  }
 }
 
 decorate(injectable(), PublicСollsСonfAccessors)

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -11,7 +11,8 @@ const {
   inject
 } = require('inversify')
 const {
-  getLimitNotMoreThan
+  getLimitNotMoreThan,
+  checkFilterParams
 } = require('bfx-report/workers/loc.api/helpers')
 const {
   AuthError
@@ -37,7 +38,8 @@ const {
   getPlaceholdersQuery,
   serializeVal,
   getGroupQuery,
-  getSubQuery
+  getSubQuery,
+  filterModelNameMap
 } = require('./helpers')
 const {
   RemoveListElemsError,
@@ -319,7 +321,12 @@ class SqliteDAO extends DAO {
       additionalModel,
       schema = {},
       isExcludePrivate = true
-    } = {}) {
+    } = {}
+  ) {
+    const filterModelName = filterModelNameMap.get(method)
+
+    checkFilterParams(filterModelName, args)
+
     const user = isPublic ? null : await this.checkAuthInDb(args)
     const methodColl = {
       ...this._getMethodCollMap().get(method),

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -34,6 +34,7 @@ const {
   getOrderQuery,
   getUniqueIndexQuery,
   getInsertableArrayObjectsFilter,
+  getStatusMessagesFilter,
   getProjectionQuery,
   getPlaceholdersQuery,
   serializeVal,
@@ -348,10 +349,18 @@ class SqliteDAO extends DAO {
     const _model = { ...model, ...additionalModel }
 
     const exclude = ['_id']
-    const filter = getInsertableArrayObjectsFilter(
+    const statusMessagesfilter = getStatusMessagesFilter(
       methodColl,
       params
     )
+    const insertableArrayObjectsFilter = getInsertableArrayObjectsFilter(
+      methodColl,
+      params
+    )
+    const filter = {
+      ...insertableArrayObjectsFilter,
+      ...statusMessagesfilter
+    }
 
     if (!isPublic) {
       exclude.push('user_id')

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -141,7 +141,7 @@ class SqliteDAO extends DAO {
   }
 
   async _createIndexisIfNotExists () {
-    for (let currItem of this._getMethodCollMap()) {
+    for (const currItem of this._getMethodCollMap()) {
       const item = currItem[1]
 
       if (item.type === 'insertable:array:objects') {
@@ -533,7 +533,7 @@ class SqliteDAO extends DAO {
     const res = await this.updateCollBy(
       'users',
       pick(data, props),
-      omit(data, [ ...props, '_id' ])
+      omit(data, [...props, '_id'])
     )
 
     if (res && res.changes < 1) {

--- a/workers/loc.api/sync/dao/helpers/filter-model-name-map.js
+++ b/workers/loc.api/sync/dao/helpers/filter-model-name-map.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const { upperFirst } = require('lodash')
+const {
+  FILTER_MODELS_NAMES
+} = require('bfx-report/workers/loc.api/helpers')
+
+module.exports = Object.values(FILTER_MODELS_NAMES)
+  .reduce((map, name) => {
+    const key = `_get${upperFirst(name)}`
+
+    map.set(key, name)
+
+    return map
+  }, new Map())

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -1,20 +1,10 @@
 'use strict'
 
+const getSymbolFilter = require('./get-symbol-filter')
+
 const _isInsertableArrayObjects = (type = '') => {
   return /^((hidden:)|(public:)|())insertable:array:objects$/i
     .test(type)
-}
-
-const _getSymbFilter = ({ symbol } = {}) => {
-  if (typeof symbol === 'string') {
-    return symbol
-  }
-  if (
-    Array.isArray(symbol) &&
-    symbol.length === 1
-  ) {
-    return symbol[0]
-  }
 }
 
 module.exports = (
@@ -34,15 +24,18 @@ module.exports = (
   const {
     start = 0,
     end = Date.now(),
+    symbol,
     isMarginFundingPayment,
     filter: reqFilter = {}
   } = { ...params }
+  const symbFilter = getSymbolFilter(symbol, symbolFieldName)
   const filter = {
     ...reqFilter,
     _dateFieldName: dateFieldName,
     start,
     end,
-    ...additionalFilteringProps
+    ...additionalFilteringProps,
+    ...symbFilter
   }
 
   if (
@@ -51,12 +44,6 @@ module.exports = (
       .some(key => key === '_isMarginFundingPayment')
   ) {
     filter._isMarginFundingPayment = Number(isMarginFundingPayment)
-  }
-
-  const symbFilter = _getSymbFilter(params)
-
-  if (symbFilter) {
-    filter[symbolFieldName] = symbFilter
   }
 
   return filter

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -34,9 +34,11 @@ module.exports = (
   const {
     start = 0,
     end = Date.now(),
-    isMarginFundingPayment
-  } = params
+    isMarginFundingPayment,
+    filter: reqFilter = {}
+  } = { ...params }
   const filter = {
+    ...reqFilter,
     _dateFieldName: dateFieldName,
     start,
     end,

--- a/workers/loc.api/sync/dao/helpers/get-status-messages-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-status-messages-filter.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const ALLOWED_COLLS = require('../../allowed.colls')
+const getSymbolFilter = require('./get-symbol-filter')
+
+module.exports = (
+  {
+    name,
+    symbolFieldName,
+    additionalFilteringProps
+  } = {},
+  params = {}
+) => {
+  if (name !== ALLOWED_COLLS.STATUS_MESSAGES) {
+    return {}
+  }
+
+  const {
+    type,
+    symbol,
+    filter: reqFilter = {}
+  } = { ...params }
+  const symbFilter = getSymbolFilter(symbol, symbolFieldName)
+  const filter = {
+    ...reqFilter,
+    _type: type,
+    ...additionalFilteringProps,
+    ...symbFilter
+  }
+
+  return filter
+}

--- a/workers/loc.api/sync/dao/helpers/get-symbol-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-symbol-filter.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = (symbol, symbolFieldName) => {
+  if (typeof symbol === 'string') {
+    return { [symbolFieldName]: symbol }
+  }
+  if (
+    Array.isArray(symbol) &&
+    symbol.length === 1
+  ) {
+    return { [symbolFieldName]: symbol[0] }
+  }
+
+  return {}
+}

--- a/workers/loc.api/sync/dao/helpers/get-where-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-where-query.js
@@ -83,7 +83,10 @@ const _getIsNullOperator = (
   filter
 ) => {
   if (
-    fieldName !== '$isNull' ||
+    (
+      fieldName !== '$isNull' &&
+      fieldName !== '$isNotNull'
+    ) ||
     (
       Array.isArray(filter[fieldName]) &&
       filter[fieldName].length === 0
@@ -92,9 +95,14 @@ const _getIsNullOperator = (
     return false
   }
 
-  return Array.isArray(filter[fieldName])
-    ? filter[fieldName].map(name => `${name} IS NULL`).join(' AND ')
-    : `${filter[fieldName]} IS NULL`
+  const not = fieldName === '$isNotNull'
+    ? ' NOT'
+    : ''
+  const valueArr = Array.isArray(filter[fieldName])
+    ? filter[fieldName]
+    : [filter[fieldName]]
+
+  return valueArr.map(name => `${name} IS${not} NULL`).join(' AND ')
 }
 
 const _isOrOp = (filter) => (

--- a/workers/loc.api/sync/dao/helpers/get-where-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-where-query.js
@@ -26,6 +26,9 @@ const _getCompareOperator = (
   if (origFieldName === '$lte') {
     return '<='
   }
+  if (origFieldName === '$like') {
+    return 'LIKE'
+  }
   if (isArr) {
     return origFieldName === '$not' ? 'NOT IN' : 'IN'
   }
@@ -149,7 +152,7 @@ module.exports = (filter = {}, isNotSetWhereClause) => {
   const operator = isOrOp
     ? 'OR'
     : 'AND'
-  const conditions = ['$gt', '$gte', '$lt', '$lte', '$not']
+  const conditions = ['$gt', '$gte', '$lt', '$lte', '$not', '$like']
   const hiddenFields = ['_dateFieldName']
   const keys = Object.keys(omit(_filter, hiddenFields))
   const where = keys.reduce(

--- a/workers/loc.api/sync/dao/helpers/get-where-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-where-query.js
@@ -29,11 +29,28 @@ const _getCompareOperator = (
   if (origFieldName === '$like') {
     return 'LIKE'
   }
+  if (origFieldName === '$ne') {
+    return '!='
+  }
+  if (origFieldName === '$eq') {
+    return '='
+  }
   if (isArr) {
-    return origFieldName === '$not' ? 'NOT IN' : 'IN'
+    if (origFieldName === '$in') {
+      return 'IN'
+    }
+    if (origFieldName === '$nin') {
+      return 'NOT IN'
+    }
+
+    return origFieldName === '$not'
+      ? 'NOT IN'
+      : 'IN'
   }
 
-  return origFieldName === '$not' ? '!=' : '='
+  return origFieldName === '$not'
+    ? '!='
+    : '='
 }
 
 const _getKeysAndValuesForWhereQuery = (
@@ -152,7 +169,18 @@ module.exports = (filter = {}, isNotSetWhereClause) => {
   const operator = isOrOp
     ? 'OR'
     : 'AND'
-  const conditions = ['$gt', '$gte', '$lt', '$lte', '$not', '$like']
+  const conditions = [
+    '$gt',
+    '$gte',
+    '$lt',
+    '$lte',
+    '$not',
+    '$like',
+    '$eq',
+    '$ne',
+    '$in',
+    '$nin'
+  ]
   const hiddenFields = ['_dateFieldName']
   const keys = Object.keys(omit(_filter, hiddenFields))
   const where = keys.reduce(

--- a/workers/loc.api/sync/dao/helpers/get-where-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-where-query.js
@@ -121,6 +121,36 @@ const _isCondition = (
   ))
 }
 
+const _getCompareOpAndKey = (
+  compareOperator,
+  key,
+  subValues
+) => {
+  if (
+    compareOperator === '=' &&
+    subValues[key] === null
+  ) {
+    return {
+      compareOperator: 'IS NULL',
+      key: ''
+    }
+  }
+  if (
+    compareOperator === '!=' &&
+    subValues[key] === null
+  ) {
+    return {
+      compareOperator: 'IS NOT NULL',
+      key: ''
+    }
+  }
+
+  return {
+    compareOperator,
+    key: ` ${key}`
+  }
+}
+
 const _getWhereQueryAndValues = (
   op = '',
   origFieldName,
@@ -129,7 +159,7 @@ const _getWhereQueryAndValues = (
   isArr = false,
   condName = ''
 ) => {
-  const compareOperator = _getCompareOperator(
+  const _compareOperator = _getCompareOperator(
     origFieldName,
     isArr
   )
@@ -153,17 +183,25 @@ const _getWhereQueryAndValues = (
     }
     : { ...filter }
   const {
-    key,
+    key: _key,
     subValues
   } = _getKeysAndValuesForWhereQuery(
     _filter,
     _fieldNameWithCondName,
     isArr
   )
+  const {
+    compareOperator,
+    key
+  } = _getCompareOpAndKey(
+    _compareOperator,
+    _key,
+    subValues
+  )
 
   return {
     subValues,
-    subQuery: `${accum}${op}${_fieldName} ${compareOperator} ${key}`
+    subQuery: `${accum}${op}${_fieldName} ${compareOperator}${key}`
   }
 }
 

--- a/workers/loc.api/sync/dao/helpers/index.js
+++ b/workers/loc.api/sync/dao/helpers/index.js
@@ -18,6 +18,7 @@ const getPlaceholdersQuery = require('./get-placeholders-query')
 const getGroupQuery = require('./get-group-query')
 const getSubQuery = require('./get-sub-query')
 const filterModelNameMap = require('./filter-model-name-map')
+const SQL_OPERATORS = require('./sql.operators')
 
 module.exports = {
   mixUserIdToArrData,
@@ -33,5 +34,6 @@ module.exports = {
   getPlaceholdersQuery,
   getGroupQuery,
   getSubQuery,
-  filterModelNameMap
+  filterModelNameMap,
+  SQL_OPERATORS
 }

--- a/workers/loc.api/sync/dao/helpers/index.js
+++ b/workers/loc.api/sync/dao/helpers/index.js
@@ -19,6 +19,7 @@ const getGroupQuery = require('./get-group-query')
 const getSubQuery = require('./get-sub-query')
 const filterModelNameMap = require('./filter-model-name-map')
 const SQL_OPERATORS = require('./sql.operators')
+const getSymbolFilter = require('./get-symbol-filter')
 
 module.exports = {
   mixUserIdToArrData,
@@ -35,5 +36,6 @@ module.exports = {
   getGroupQuery,
   getSubQuery,
   filterModelNameMap,
-  SQL_OPERATORS
+  SQL_OPERATORS,
+  getSymbolFilter
 }

--- a/workers/loc.api/sync/dao/helpers/index.js
+++ b/workers/loc.api/sync/dao/helpers/index.js
@@ -20,6 +20,7 @@ const getSubQuery = require('./get-sub-query')
 const filterModelNameMap = require('./filter-model-name-map')
 const SQL_OPERATORS = require('./sql.operators')
 const getSymbolFilter = require('./get-symbol-filter')
+const getStatusMessagesFilter = require('./get-status-messages-filter')
 
 module.exports = {
   mixUserIdToArrData,
@@ -37,5 +38,6 @@ module.exports = {
   getSubQuery,
   filterModelNameMap,
   SQL_OPERATORS,
-  getSymbolFilter
+  getSymbolFilter,
+  getStatusMessagesFilter
 }

--- a/workers/loc.api/sync/dao/helpers/index.js
+++ b/workers/loc.api/sync/dao/helpers/index.js
@@ -17,6 +17,7 @@ const getProjectionQuery = require('./get-projection-query')
 const getPlaceholdersQuery = require('./get-placeholders-query')
 const getGroupQuery = require('./get-group-query')
 const getSubQuery = require('./get-sub-query')
+const filterModelNameMap = require('./filter-model-name-map')
 
 module.exports = {
   mixUserIdToArrData,
@@ -31,5 +32,6 @@ module.exports = {
   getProjectionQuery,
   getPlaceholdersQuery,
   getGroupQuery,
-  getSubQuery
+  getSubQuery,
+  filterModelNameMap
 }

--- a/workers/loc.api/sync/dao/helpers/serialization.js
+++ b/workers/loc.api/sync/dao/helpers/serialization.js
@@ -8,7 +8,10 @@ const serializeVal = (val) => {
   if (typeof val === 'boolean') {
     return +val
   }
-  if (typeof val === 'object') {
+  if (
+    val &&
+    typeof val === 'object'
+  ) {
     return JSON.stringify(val)
   }
 
@@ -27,12 +30,6 @@ const deserializeVal = (
     '_isMarginFundingPayment'
   ]
 ) => {
-  if (
-    typeof val === 'string' &&
-    /^null$/.test(val)
-  ) {
-    return null
-  }
   if (
     typeof val === 'number' &&
     boolFields.some(item => item === key)

--- a/workers/loc.api/sync/dao/helpers/sql.operators.js
+++ b/workers/loc.api/sync/dao/helpers/sql.operators.js
@@ -1,0 +1,19 @@
+'use strict'
+
+module.exports = {
+  GT: '>',
+  GTE: '>=',
+  LT: '<',
+  LTE: '<=',
+  LIKE: 'LIKE',
+  NE: '!=',
+  EQ: '=',
+  IN: 'IN',
+  NIN: 'NOT IN',
+  AND: 'AND',
+  OR: 'OR',
+  WHERE: 'WHERE',
+  ESCAPE: 'ESCAPE',
+  IS_NULL: 'IS NULL',
+  IS_NOT_NULL: 'IS NOT NULL'
+}

--- a/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
@@ -7,6 +7,7 @@ const {
 } = require('inversify')
 
 const TYPES = require('../../di/types')
+const { addPropsToResIfExist } = require('./helpers')
 
 class ApiMiddlewareHandlerAfter {
   constructor (
@@ -88,19 +89,11 @@ class ApiMiddlewareHandlerAfter {
   }
 
   _getPublicTrades (args, apiRes) {
-    if (args.params.symbol) {
-      const res = apiRes.res.map(item => ({
-        ...item,
-        _symbol: args.params.symbol
-      }))
-
-      return {
-        ...apiRes,
-        res
-      }
-    }
-
-    return apiRes
+    return addPropsToResIfExist(
+      args,
+      apiRes,
+      [{ from: 'symbol', to: '_symbol' }]
+    )
   }
 
   _getLedgers (args, apiRes) {
@@ -118,19 +111,20 @@ class ApiMiddlewareHandlerAfter {
   }
 
   _getCandles (args, apiRes) {
-    if (args.params.symbol) {
-      const res = apiRes.res.map(item => ({
-        ...item,
-        _symbol: args.params.symbol
-      }))
+    return addPropsToResIfExist(
+      args,
+      apiRes,
+      [{ from: 'symbol', to: '_symbol' }]
+    )
+  }
 
-      return {
-        ...apiRes,
-        res
-      }
-    }
-
-    return apiRes
+  _getStatusMessages (args, apiRes) {
+    console.log('[status-mess-args]:'.bgBlue, args)
+    return addPropsToResIfExist(
+      args,
+      apiRes,
+      [{ from: 'type', to: '_type' }]
+    )
   }
 }
 

--- a/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
@@ -119,7 +119,6 @@ class ApiMiddlewareHandlerAfter {
   }
 
   _getStatusMessages (args, apiRes) {
-    console.log('[status-mess-args]:'.bgBlue, args)
     return addPropsToResIfExist(
       args,
       apiRes,

--- a/workers/loc.api/sync/data.inserter/helpers/index.js
+++ b/workers/loc.api/sync/data.inserter/helpers/index.js
@@ -13,7 +13,8 @@ const {
   compareElemsDbAndApi,
   normalizeApiData,
   getAuthFromDb,
-  getAllowedCollsNames
+  getAllowedCollsNames,
+  addPropsToResIfExist
 } = require('./utils')
 const convertCurrency = require('./convert-currency')
 
@@ -27,5 +28,6 @@ module.exports = {
   normalizeApiData,
   getAuthFromDb,
   getAllowedCollsNames,
-  convertCurrency
+  convertCurrency,
+  addPropsToResIfExist
 }

--- a/workers/loc.api/sync/data.inserter/helpers/utils.js
+++ b/workers/loc.api/sync/data.inserter/helpers/utils.js
@@ -7,7 +7,7 @@ const {
 
 const invertSort = (sortArr) => {
   return sortArr.map(item => {
-    const _arr = [ ...item ]
+    const _arr = [...item]
 
     _arr[1] = item[1] > 0 ? -1 : 1
 

--- a/workers/loc.api/sync/data.inserter/helpers/utils.js
+++ b/workers/loc.api/sync/data.inserter/helpers/utils.js
@@ -100,6 +100,65 @@ const getAllowedCollsNames = (allowedColls) => {
     .filter(name => !(/^_.*/.test(name)))
 }
 
+const addPropsToResIfExist = (
+  args = {},
+  apiRes = [],
+  props = []
+) => {
+  const { params } = { ...args }
+  const isApiResObject = (
+    apiRes &&
+    typeof apiRes === 'object' &&
+    !Array.isArray(apiRes)
+  )
+  const incomingRes = (
+    isApiResObject &&
+    Array.isArray(apiRes.res)
+  )
+    ? apiRes.res
+    : apiRes
+  const isEmptyProps = props.every(({ from, to }) => {
+    return (
+      typeof to !== 'string' ||
+      typeof from !== 'string' ||
+      typeof params[from] === 'undefined'
+    )
+  })
+
+  if (
+    !Array.isArray(incomingRes) ||
+    isEmptyProps
+  ) {
+    return apiRes
+  }
+
+  const res = incomingRes.map((item) => {
+    const additionalProps = props.reduce((accum, { from, to }) => {
+      if (
+        typeof to !== 'string' ||
+        typeof from !== 'string' ||
+        typeof params[from] === 'undefined'
+      ) {
+        return accum
+      }
+
+      return {
+        ...accum,
+        [to]: params[from]
+      }
+    }, {})
+
+    return {
+      ...item,
+      ...additionalProps
+    }
+  })
+
+  return isApiResObject
+    ? { ...apiRes, res }
+    : res
+}
+
 module.exports = {
   invertSort,
   filterMethodCollMap,
@@ -107,5 +166,6 @@ module.exports = {
   compareElemsDbAndApi,
   normalizeApiData,
   getAuthFromDb,
-  getAllowedCollsNames
+  getAllowedCollsNames,
+  addPropsToResIfExist
 }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -240,7 +240,7 @@ class DataInserter extends EventEmitter {
   }
 
   async _checkNewDataPublicArrObjType (methodCollMap) {
-    for (let [method, schema] of methodCollMap) {
+    for (const [method, schema] of methodCollMap) {
       if (!this._isInsertableArrObjTypeOfColl(schema, true)) {
         continue
       }
@@ -399,7 +399,7 @@ class DataInserter extends EventEmitter {
   }
 
   async _checkNewDataArrObjType (auth, methodCollMap) {
-    for (let [method, item] of methodCollMap) {
+    for (const [method, item] of methodCollMap) {
       if (!this._isInsertableArrObjTypeOfColl(item)) {
         continue
       }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -731,7 +731,8 @@ class DataInserter extends EventEmitter {
           symbol,
           filter: {
             $gte: { [dateFieldName]: start }
-          }
+          },
+          type: 'deriv' // TODO:
         }
       )
       const apiRes = await this._getDataFromApi(methodApi, args)

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -694,6 +694,82 @@ class DataInserter extends EventEmitter {
     }
   }
 
+  async _updateConfigurableApiDataArrObjTypeToDb (
+    methodApi,
+    schema
+  ) {
+    const {
+      dateFieldName,
+      name: collName,
+      fields,
+      model
+    } = { ...schema }
+
+    const publicСollsСonf = await this.dao.getElemsInCollBy(
+      'publicСollsСonf',
+      {
+        filter: { confName: schema.confName },
+        minPropName: 'start',
+        groupPropName: 'symbol'
+      }
+    )
+
+    if (isEmpty(publicСollsСonf)) {
+      return
+    }
+
+    const elemsFromApi = []
+
+    for (const { symbol, start } of publicСollsСonf) {
+      const args = this._getMethodArgMap(
+        methodApi,
+        {},
+        null,
+        null,
+        null,
+        {
+          symbol,
+          filter: {
+            $gte: { [dateFieldName]: start }
+          }
+        }
+      )
+      const apiRes = await this._getDataFromApi(methodApi, args)
+      const oneSymbElemsFromApi = (
+        apiRes &&
+        typeof apiRes === 'object' &&
+        !Array.isArray(apiRes) &&
+        Array.isArray(apiRes.res)
+      )
+        ? apiRes.res
+        : apiRes
+
+      if (!Array.isArray(oneSymbElemsFromApi)) {
+        continue
+      }
+
+      elemsFromApi.push(...oneSymbElemsFromApi)
+    }
+
+    if (elemsFromApi.length > 0) {
+      const lists = fields.reduce((obj, curr) => {
+        obj[curr] = elemsFromApi.map(item => item[curr])
+
+        return obj
+      }, {})
+
+      await this.dao.removeElemsFromDbIfNotInLists(
+        collName,
+        lists
+      )
+      await this.dao.insertElemsToDbIfNotExists(
+        collName,
+        null,
+        normalizeApiData(elemsFromApi, model)
+      )
+    }
+  }
+
   async _updateApiDataArrObjTypeToDb (
     methodApi,
     schema
@@ -706,10 +782,33 @@ class DataInserter extends EventEmitter {
       name: collName,
       fields,
       model
-    } = schema
+    } = { ...schema }
 
-    const args = this._getMethodArgMap(methodApi, {}, null, null, null)
-    const elemsFromApi = await this._getDataFromApi(methodApi, args)
+    if (collName === this.ALLOWED_COLLS.STATUS_MESSAGES) {
+      await this._updateConfigurableApiDataArrObjTypeToDb(
+        methodApi,
+        schema
+      )
+
+      return
+    }
+
+    const args = this._getMethodArgMap(
+      methodApi,
+      {},
+      null,
+      null,
+      null
+    )
+    const apiRes = await this._getDataFromApi(methodApi, args)
+    const elemsFromApi = (
+      apiRes &&
+      typeof apiRes === 'object' &&
+      !Array.isArray(apiRes) &&
+      Array.isArray(apiRes.res)
+    )
+      ? apiRes.res
+      : apiRes
 
     if (
       Array.isArray(elemsFromApi) &&
@@ -738,8 +837,13 @@ class DataInserter extends EventEmitter {
     auth,
     limit,
     start = 0,
-    end = Date.now()
+    end = Date.now(),
+    params
   ) {
+    const _limit = limit !== null
+      ? limit
+      : this._methodCollMap.get(method).maxLimit
+
     return {
       auth: {
         ...(auth && typeof auth === 'object'
@@ -750,9 +854,8 @@ class DataInserter extends EventEmitter {
           })
       },
       params: {
-        limit: limit !== null
-          ? limit
-          : this._methodCollMap.get(method).maxLimit,
+        ...params,
+        limit: _limit,
         end,
         start
       }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -718,38 +718,41 @@ class DataInserter extends EventEmitter {
       return
     }
 
+    const syncingTypes = ['deriv']
     const elemsFromApi = []
 
     for (const { symbol, start } of publicСollsСonf) {
-      const args = this._getMethodArgMap(
-        methodApi,
-        {},
-        null,
-        null,
-        null,
-        {
-          symbol,
-          filter: {
-            $gte: { [dateFieldName]: start }
-          },
-          type: 'deriv' // TODO:
+      for (const type of syncingTypes) {
+        const args = this._getMethodArgMap(
+          methodApi,
+          {},
+          null,
+          null,
+          null,
+          {
+            symbol,
+            filter: {
+              $gte: { [dateFieldName]: start }
+            },
+            type
+          }
+        )
+        const apiRes = await this._getDataFromApi(methodApi, args)
+        const oneSymbElemsFromApi = (
+          apiRes &&
+          typeof apiRes === 'object' &&
+          !Array.isArray(apiRes) &&
+          Array.isArray(apiRes.res)
+        )
+          ? apiRes.res
+          : apiRes
+
+        if (!Array.isArray(oneSymbElemsFromApi)) {
+          continue
         }
-      )
-      const apiRes = await this._getDataFromApi(methodApi, args)
-      const oneSymbElemsFromApi = (
-        apiRes &&
-        typeof apiRes === 'object' &&
-        !Array.isArray(apiRes) &&
-        Array.isArray(apiRes.res)
-      )
-        ? apiRes.res
-        : apiRes
 
-      if (!Array.isArray(oneSymbElemsFromApi)) {
-        continue
+        elemsFromApi.push(...oneSymbElemsFromApi)
       }
-
-      elemsFromApi.push(...oneSymbElemsFromApi)
     }
 
     if (elemsFromApi.length > 0) {

--- a/workers/loc.api/sync/progress/index.js
+++ b/workers/loc.api/sync/progress/index.js
@@ -27,7 +27,10 @@ class Progress extends EventEmitter {
   }
 
   async setProgress (progress) {
-    const isError = progress instanceof Error
+    const isError = (
+      progress instanceof Error ||
+      (typeof progress === 'string' && /error/gi.test(progress))
+    )
     const _progress = isError
       ? progress.toString()
       : progress

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -436,6 +436,22 @@ const _methodCollMap = new Map([
     }
   ],
   [
+    '_getStatusMessages',
+    {
+      name: ALLOWED_COLLS.STATUS_MESSAGES,
+      maxLimit: 5000,
+      dateFieldName: 'timestamp',
+      symbolFieldName: 'key',
+      sort: [['timestamp', -1]],
+      hasNewData: false,
+      start: [],
+      confName: 'statusMessagesConf',
+      type: 'public:updatable:array:objects', // TODO:
+      fieldsOfUniqueIndex: ['timestamp', 'key'],
+      model: { ..._models.get(ALLOWED_COLLS.PUBLIC_TRADES) }
+    }
+  ],
+  [
     '_getOrders',
     {
       name: ALLOWED_COLLS.ORDERS,

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -278,6 +278,19 @@ const _models = new Map([
     }
   ],
   [
+    ALLOWED_COLLS.STATUS_MESSAGES,
+    {
+      _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+      key: 'VARCHAR(255)',
+      timestamp: 'BIGINT',
+      price: 'DECIMAL(22,12)',
+      priceSpot: 'DECIMAL(22,12)',
+      fundBal: 'DECIMAL(22,12)',
+      fundingAccrued: 'DECIMAL(22,12)',
+      fundingStep: 'DECIMAL(22,12)'
+    }
+  ],
+  [
     'publicСollsСonf',
     {
       _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -440,15 +440,23 @@ const _methodCollMap = new Map([
     {
       name: ALLOWED_COLLS.STATUS_MESSAGES,
       maxLimit: 5000,
+      fields: [
+        'key',
+        'timestamp',
+        'price',
+        'priceSpot',
+        'fundBal',
+        'fundingAccrued',
+        'fundingStep'
+      ],
       dateFieldName: 'timestamp',
       symbolFieldName: 'key',
       sort: [['timestamp', -1]],
-      hasNewData: false,
-      start: [],
+      hasNewData: true,
       confName: 'statusMessagesConf',
-      type: 'public:updatable:array:objects', // TODO:
+      type: 'public:updatable:array:objects',
       fieldsOfUniqueIndex: ['timestamp', 'key'],
-      model: { ..._models.get(ALLOWED_COLLS.PUBLIC_TRADES) }
+      model: { ..._models.get(ALLOWED_COLLS.STATUS_MESSAGES) }
     }
   ],
   [

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -456,7 +456,7 @@ const _methodCollMap = new Map([
       hasNewData: true,
       confName: 'statusMessagesConf',
       type: 'public:updatable:array:objects',
-      fieldsOfUniqueIndex: ['timestamp', 'key'],
+      fieldsOfUniqueIndex: ['timestamp', 'key', '_type'],
       model: { ..._models.get(ALLOWED_COLLS.STATUS_MESSAGES) }
     }
   ],

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -287,7 +287,8 @@ const _models = new Map([
       priceSpot: 'DECIMAL(22,12)',
       fundBal: 'DECIMAL(22,12)',
       fundingAccrued: 'DECIMAL(22,12)',
-      fundingStep: 'DECIMAL(22,12)'
+      fundingStep: 'DECIMAL(22,12)',
+      _type: 'VARCHAR(255)'
     }
   ],
   [


### PR DESCRIPTION
This PR adds status messages report to sync mode. Basic changes:
  - adds `getStatusMessagesConf` method to the main service
  - adds `editStatusMessagesConf` method to the main service
  - adds `getStatusMessages` method to the main service
  - adds corresponding test coverage

Example of a request:
```js
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "getStatusMessagesCsv",
    "params": {
    	"type": "deriv", // by default
    	"symbol": ["tBTCF0:USTF0", "tETHF0:USTF0"],  // ['ALL'] by default
    }
}
```

**Depends** on this PR: [bitfinexcom/bfx-report#149](https://github.com/bitfinexcom/bfx-report/pull/149)