### PR TITLE
Add ability to filter affiliate rebate for ledgers

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -55,16 +55,23 @@ git stash
 cd $backendFolder
 
 git submodule sync
-git submodule update --remote
+git submodule update --init --recursive
 git pull --recurse-submodules
+git submodule update --remote
 npm i
 
 cd $expressFolder
 git submodule sync
+git submodule update --init --recursive
+git pull --recurse-submodules
+git submodule update --remote
+
 git stash
 cd $frontendFolder
-git submodule update --remote
+git submodule sync
+git submodule update --init --recursive
 git pull --recurse-submodules
+git submodule update --remote
 npm i
 
 if [ $isDevEnv != 0 ]; then

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -7,6 +7,31 @@ const _isInsertableArrayObjects = (type = '') => {
     .test(type)
 }
 
+const getFieldsFilters = (
+  fieldNames = [],
+  params,
+  model
+) => {
+  return fieldNames.reduce((accum, fieldName) => {
+    const modelFieldName = `_${fieldName}`
+    const _params = { ...params }
+    const field = _params[fieldName]
+
+    if (
+      typeof field === 'boolean' &&
+      Object.keys(model)
+        .some(key => key === modelFieldName)
+    ) {
+      return {
+        ...accum,
+        [modelFieldName]: Number(field)
+      }
+    }
+
+    return accum
+  }, {})
+}
+
 module.exports = (
   {
     type,
@@ -25,25 +50,22 @@ module.exports = (
     start = 0,
     end = Date.now(),
     symbol,
-    isMarginFundingPayment,
     filter: reqFilter = {}
   } = { ...params }
   const symbFilter = getSymbolFilter(symbol, symbolFieldName)
+  const fieldsFilters = getFieldsFilters(
+    ['isMarginFundingPayment', 'isAffiliateRebate'],
+    params,
+    model
+  )
   const filter = {
     ...reqFilter,
     _dateFieldName: dateFieldName,
     start,
     end,
     ...additionalFilteringProps,
-    ...symbFilter
-  }
-
-  if (
-    typeof isMarginFundingPayment === 'boolean' &&
-    Object.keys(model)
-      .some(key => key === '_isMarginFundingPayment')
-  ) {
-    filter._isMarginFundingPayment = Number(isMarginFundingPayment)
+    ...symbFilter,
+    ...fieldsFilters
   }
 
   return filter

--- a/workers/loc.api/sync/dao/helpers/serialization.js
+++ b/workers/loc.api/sync/dao/helpers/serialization.js
@@ -27,7 +27,8 @@ const deserializeVal = (
     'renew',
     'noClose',
     'maker',
-    '_isMarginFundingPayment'
+    '_isMarginFundingPayment',
+    '_isAffiliateRebate'
   ]
 ) => {
   if (

--- a/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
@@ -7,7 +7,10 @@ const {
 } = require('inversify')
 
 const TYPES = require('../../di/types')
-const { addPropsToResIfExist } = require('./helpers')
+const {
+  addPropsToResIfExist,
+  getFlagsFromLedgerDescription
+} = require('./helpers')
 
 class ApiMiddlewareHandlerAfter {
   constructor (
@@ -99,8 +102,18 @@ class ApiMiddlewareHandlerAfter {
   _getLedgers (args, apiRes) {
     const res = apiRes.res.map(item => ({
       ...item,
-      _isMarginFundingPayment: /Margin Funding Payment/gi.test(
-        item.description
+      ...getFlagsFromLedgerDescription(
+        item,
+        [
+          {
+            fieldName: '_isMarginFundingPayment',
+            pattern: 'Margin Funding Payment'
+          },
+          {
+            fieldName: '_isAffiliateRebate',
+            pattern: 'Affiliate Rebate'
+          }
+        ]
       )
     }))
 

--- a/workers/loc.api/sync/data.inserter/helpers/get-flags-from-ledger-description.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-flags-from-ledger-description.js
@@ -1,0 +1,27 @@
+'use strict'
+
+module.exports = (
+  ledger,
+  schemas = []
+) => {
+  if (
+    !ledger ||
+    typeof ledger !== 'object' ||
+    typeof ledger.description !== 'string'
+  ) {
+    return {}
+  }
+
+  return schemas.reduce((accum, schema) => {
+    const {
+      fieldName,
+      pattern
+    } = { ...schema }
+    const regExp = new RegExp(pattern, 'i')
+
+    return {
+      ...accum,
+      [fieldName]: regExp.test(ledger.description)
+    }
+  }, {})
+}

--- a/workers/loc.api/sync/data.inserter/helpers/index.js
+++ b/workers/loc.api/sync/data.inserter/helpers/index.js
@@ -17,6 +17,7 @@ const {
   addPropsToResIfExist
 } = require('./utils')
 const convertCurrency = require('./convert-currency')
+const getFlagsFromLedgerDescription = require('./get-flags-from-ledger-description')
 
 module.exports = {
   searchClosePriceAndSumAmount,
@@ -29,5 +30,6 @@ module.exports = {
   getAuthFromDb,
   getAllowedCollsNames,
   convertCurrency,
-  addPropsToResIfExist
+  addPropsToResIfExist,
+  getFlagsFromLedgerDescription
 }

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -33,6 +33,7 @@ const _models = new Map([
       description: 'TEXT',
       wallet: 'VARCHAR(255)',
       _isMarginFundingPayment: 'INT',
+      _isAffiliateRebate: 'INT',
       user_id: `INT NOT NULL,
         CONSTRAINT ledgers_fk_#{field}
         FOREIGN KEY (#{field})


### PR DESCRIPTION
This PR adds an ability to filter affiliate rebate for ledgers
Request example:
```
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "getLedgers",
    "params": {
    	"isAffiliateRebate": true
    }
}
```