### PR TITLE
Add traded volume report

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-reports-framework",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Bitfinex reports framework",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/test/2-additional-api-sync-mode-sqlite.spec.js
+++ b/test/2-additional-api-sync-mode-sqlite.spec.js
@@ -615,4 +615,30 @@ describe('Additional sync mode API with SQLite', () => {
 
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
+
+  it('it should be successfully performed by the getTradedVolumeCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getTradedVolumeCsv',
+        params: {
+          end,
+          start,
+          timeframe: 'day',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
 })

--- a/test/2-additional-api-sync-mode-sqlite.spec.js
+++ b/test/2-additional-api-sync-mode-sqlite.spec.js
@@ -22,7 +22,8 @@ const {
 const {
   connToSQLite,
   closeSQLite,
-  delay
+  delay,
+  getParamsArrToTestTimeframeGrouping
 } = require('./helpers/helpers.core')
 const {
   createMockRESTv2SrvWithDate
@@ -156,17 +157,7 @@ describe('Additional sync mode API with SQLite', () => {
   it('it should be successfully performed by the getBalanceHistory method', async function () {
     this.timeout(5000)
 
-    const timeframeArr = ['day', 'month', 'year']
-    const paramsArr = Array(timeframeArr.length)
-      .fill({ start, end })
-      .map((item, i) => {
-        const timeframeIndex = i % timeframeArr.length
-
-        return {
-          ...item,
-          timeframe: timeframeArr[timeframeIndex]
-        }
-      })
+    const paramsArr = getParamsArrToTestTimeframeGrouping({ start, end })
 
     for (const params of paramsArr) {
       const res = await agent
@@ -198,17 +189,7 @@ describe('Additional sync mode API with SQLite', () => {
   it('it should be successfully performed by the getWinLoss method', async function () {
     this.timeout(10000)
 
-    const timeframeArr = ['day', 'month', 'year']
-    const paramsArr = Array(timeframeArr.length)
-      .fill({ start, end })
-      .map((item, i) => {
-        const timeframeIndex = i % timeframeArr.length
-
-        return {
-          ...item,
-          timeframe: timeframeArr[timeframeIndex]
-        }
-      })
+    const paramsArr = getParamsArrToTestTimeframeGrouping({ start, end })
 
     for (const params of paramsArr) {
       const res = await agent
@@ -436,6 +417,38 @@ describe('Additional sync mode API with SQLite', () => {
           'transactionId'
         ])
       })
+    }
+  })
+
+  it('it should be successfully performed by the getTradedVolume method', async function () {
+    this.timeout(10000)
+
+    const paramsArr = getParamsArrToTestTimeframeGrouping({ start, end })
+
+    for (const params of paramsArr) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send({
+          auth,
+          method: 'getTradedVolume',
+          params,
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isArray(res.body.result)
+
+      const resItem = res.body.result[0]
+
+      assert.isObject(resItem)
+      assert.containsAllKeys(resItem, [
+        'mts',
+        'USD'
+      ])
     }
   })
 

--- a/test/helpers/helpers.core.js
+++ b/test/helpers/helpers.core.js
@@ -39,8 +39,25 @@ const closeSQLite = (db) => {
 
 const delay = (mc = 500) => _delay(mc)
 
+const getParamsArrToTestTimeframeGrouping = (
+  params = {},
+  timeframes = ['day', 'month', 'year']
+) => {
+  return Array(timeframes.length)
+    .fill({ ...params })
+    .map((item, i) => {
+      const timeframeIndex = i % timeframes.length
+
+      return {
+        ...item,
+        timeframe: timeframes[timeframeIndex]
+      }
+    })
+}
+
 module.exports = {
   connToSQLite,
   closeSQLite,
-  delay
+  delay,
+  getParamsArrToTestTimeframeGrouping
 }

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -85,7 +85,8 @@ module.exports = ({
           ['_winLoss', TYPES.WinLoss],
           ['_positionsSnapshot', TYPES.PositionsSnapshot],
           ['_fullSnapshotReport', TYPES.FullSnapshotReport],
-          ['_fullTaxReport', TYPES.FullTaxReport]
+          ['_fullTaxReport', TYPES.FullTaxReport],
+          ['_tradedVolume', TYPES.TradedVolume]
         ]
       })
     rebind(TYPES.RServiceDepsSchemaAliase)

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -45,6 +45,7 @@ const BalanceHistory = require('../sync/balance.history')
 const WinLoss = require('../sync/win.loss')
 const PositionsSnapshot = require('../sync/positions.snapshot')
 const FullSnapshotReport = require('../sync/full.snapshot.report')
+const TradedVolume = require('../sync/traded.volume')
 const CurrencyConverter = require('../sync/currency.converter')
 const CsvJobData = require('../generate-csv/csv.job.data')
 const {
@@ -194,6 +195,8 @@ module.exports = ({
       .to(PositionsSnapshot)
     bind(TYPES.FullSnapshotReport)
       .to(FullSnapshotReport)
+    bind(TYPES.TradedVolume)
+      .to(TradedVolume)
     bind(TYPES.FullSnapshotReportCsvWriter)
       .toConstantValue(
         bindDepsToFn(

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -36,5 +36,6 @@ module.exports = {
   FullTaxReportCsvWriter: Symbol.for('FullTaxReportCsvWriter'),
   MigrationsFactory: Symbol.for('MigrationsFactory'),
   DbMigratorFactory: Symbol.for('DbMigratorFactory'),
-  SqliteDbMigrator: Symbol.for('SqliteDbMigrator')
+  SqliteDbMigrator: Symbol.for('SqliteDbMigrator'),
+  TradedVolume: Symbol.for('TradedVolume')
 }

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -390,6 +390,44 @@ class CsvJobData extends BaseCsvJobData {
 
     return jobData
   }
+
+  async getTradedVolumeCsvJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args, 'paramsSchemaForTradedVolumeCsv')
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      this.rService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args)
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getTradedVolume',
+      fileNamesMap: [['getTradedVolume', 'traded-volume']],
+      args: csvArgs,
+      propNameForPagination: null,
+      columnsCsv: {
+        USD: 'USD',
+        mts: 'DATE'
+      },
+      formatSettings: {
+        mts: 'date'
+      }
+    }
+
+    return jobData
+  }
 }
 
 decorate(inject(TYPES.RService), CsvJobData, 0)

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -231,6 +231,15 @@ const paramsSchemaForFullTaxReportCsv = {
   }
 }
 
+const paramsSchemaForTradedVolumeCsv = {
+  type: 'object',
+  properties: {
+    ...cloneDeep(paramsSchemaForTradedVolumeApi.properties),
+    timezone,
+    dateFormat
+  }
+}
+
 module.exports = {
   paramsSchemaForCandlesApi,
   paramsSchemaForRiskApi,
@@ -245,5 +254,6 @@ module.exports = {
   paramsSchemaForWinLossCsv,
   paramsSchemaForPositionsSnapshotCsv,
   paramsSchemaForFullSnapshotReportCsv,
-  paramsSchemaForFullTaxReportCsv
+  paramsSchemaForFullTaxReportCsv,
+  paramsSchemaForTradedVolumeCsv
 }

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -145,6 +145,29 @@ const paramsSchemaForWinLossApi = {
   }
 }
 
+const paramsSchemaForTradedVolumeApi = {
+  type: 'object',
+  properties: {
+    timeframe: {
+      type: 'string',
+      enum: [
+        'day',
+        'month',
+        'year'
+      ]
+    },
+    start: {
+      type: 'integer'
+    },
+    end: {
+      type: 'integer'
+    },
+    symbol: {
+      type: 'string'
+    }
+  }
+}
+
 const {
   timezone,
   dateFormat
@@ -216,6 +239,7 @@ module.exports = {
   paramsSchemaForPositionsSnapshotApi,
   paramsSchemaForFullSnapshotReportApi,
   paramsSchemaForFullTaxReportApi,
+  paramsSchemaForTradedVolumeApi,
   paramsSchemaForRiskCsv,
   paramsSchemaForBalanceHistoryCsv,
   paramsSchemaForWinLossCsv,

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -163,7 +163,7 @@ const paramsSchemaForTradedVolumeApi = {
       type: 'integer'
     },
     symbol: {
-      type: 'string'
+      type: ['string', 'array']
     }
   }
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -934,6 +934,15 @@ class FrameworkReportService extends ReportService {
       )
     }, 'getFullTaxReportCsv', cb)
   }
+
+  getTradedVolumeCsv (space, args, cb) {
+    return this._responder(() => {
+      return this._generateCsv(
+        'getTradedVolumeCsvJobData',
+        args
+      )
+    }, 'getTradedVolumeCsv', cb)
+  }
 }
 
 module.exports = FrameworkReportService

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -866,6 +866,18 @@ class FrameworkReportService extends ReportService {
     }, 'getFullTaxReport', cb)
   }
 
+  getTradedVolume (space, args, cb) {
+    return this._responder(async () => {
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        throw new DuringSyncMethodAccessError()
+      }
+
+      checkParams(args, 'paramsSchemaForTradedVolumeApi')
+
+      return this._tradedVolume.getTradedVolume(args)
+    }, 'getTradedVolume', cb)
+  }
+
   /**
    * @override
    */

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v1.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v1.js
@@ -1,4 +1,4 @@
-'use strinc'
+'use strict'
 
 const AbstractMigration = require('./abstract.migration')
 const {

--- a/workers/loc.api/sync/traded.volume/index.js
+++ b/workers/loc.api/sync/traded.volume/index.js
@@ -11,28 +11,86 @@ const TYPES = require('../../di/types')
 class TradedVolume {
   constructor (
     dao,
+    ALLOWED_COLLS,
+    syncSchema,
     FOREX_SYMBS
   ) {
     this.dao = dao
+    this.ALLOWED_COLLS = ALLOWED_COLLS
+    this.syncSchema = syncSchema
     this.FOREX_SYMBS = FOREX_SYMBS
+  }
+
+  async _getTrades ({
+    auth,
+    start,
+    end,
+    symbol
+  }) {
+    const user = await this.dao.checkAuthInDb({ auth })
+
+    const symbFilter = (
+      Array.isArray(symbol) &&
+      symbol.length !== 0
+    )
+      ? { $in: { symbol } }
+      : {}
+    const tradesModel = this.syncSchema.getModelsMap()
+      .get(this.ALLOWED_COLLS.TRADES)
+
+    return this.dao.getElemsInCollBy(
+      this.ALLOWED_COLLS.TRADES,
+      {
+        filter: {
+          user_id: user._id,
+          $lte: { mtsCreate: end },
+          $gte: { mtsCreate: start },
+          ...symbFilter
+        },
+        sort: [['mtsCreate', -1]],
+        projection: tradesModel,
+        exclude: ['user_id'],
+        isExcludePrivate: true
+      }
+    )
   }
 
   // TODO:
   async getTradedVolume (
     {
       auth = {},
-      params: {
-        timeframe = 'day',
-        start = 0,
-        end = Date.now(),
-        symbol
-      } = {}
+      params = {}
     } = {}
-  ) {}
+  ) {
+    const {
+      timeframe = 'day',
+      start = 0,
+      end = Date.now(),
+      symbol: symbs
+    } = { ...params }
+    const _symbol = Array.isArray(symbs)
+      ? symbs
+      : [symbs]
+    const symbol = _symbol.filter((s) => (
+      s && typeof s === 'string'
+    ))
+    const args = {
+      auth,
+      start,
+      end,
+      symbol
+    }
+
+    const trades = await this._getTrades(args)
+
+    return trades // TODO:
+  }
 }
 
 decorate(injectable(), TradedVolume)
 decorate(inject(TYPES.DAO), TradedVolume, 0)
-decorate(inject(TYPES.FOREX_SYMBS), TradedVolume, 1)
+decorate(inject(TYPES.ALLOWED_COLLS), TradedVolume, 1)
+decorate(inject(TYPES.SyncSchema), TradedVolume, 2)
+decorate(inject(TYPES.FOREX_SYMBS), TradedVolume, 3)
 
 module.exports = TradedVolume

--- a/workers/loc.api/sync/traded.volume/index.js
+++ b/workers/loc.api/sync/traded.volume/index.js
@@ -8,6 +8,7 @@ const {
 
 const TYPES = require('../../di/types')
 const {
+  calcGroupedData,
   groupByTimeframe,
   splitSymbolPairs
 } = require('../helpers')
@@ -59,6 +60,7 @@ class TradedVolume {
     )
   }
 
+  // TODO: need to add currency convert
   _calcTrades (
     data = [],
     symbolFieldName,
@@ -87,6 +89,30 @@ class TradedVolume {
           : amount
       }
     }, {})
+  }
+
+  _getTradesByTimeframe () {
+    return ({ tradesGroupedByTimeframe = {} }) => {
+      const tradesArr = Object.entries(tradesGroupedByTimeframe)
+      const res = tradesArr.reduce((
+        accum,
+        [symb, amount]
+      ) => {
+        if (
+          symb !== 'USD' ||
+          !Number.isFinite(amount)
+        ) {
+          return { ...accum }
+        }
+
+        return {
+          ...accum,
+          [symb]: amount
+        }
+      }, {})
+
+      return res
+    }
   }
 
   // TODO:
@@ -131,7 +157,14 @@ class TradedVolume {
       this._calcTrades.bind(this)
     )
 
-    return tradesGroupedByTimeframe // TODO:
+    const groupedData = await calcGroupedData(
+      { tradesGroupedByTimeframe },
+      false,
+      this._getTradesByTimeframe(),
+      true
+    )
+
+    return groupedData // TODO:
   }
 }
 

--- a/workers/loc.api/sync/traded.volume/index.js
+++ b/workers/loc.api/sync/traded.volume/index.js
@@ -9,8 +9,7 @@ const {
 const TYPES = require('../../di/types')
 const {
   calcGroupedData,
-  groupByTimeframe,
-  splitSymbolPairs
+  groupByTimeframe
 } = require('../helpers')
 
 class TradedVolume {
@@ -79,18 +78,11 @@ class TradedVolume {
     }, {})
   }
 
-  _calcTradesAmount (
-    data = [],
-    symbolFieldName
-  ) {
+  _calcTradesAmount (data = []) {
     return data.map((trade = {}) => {
       const { execAmount, execPrice } = { ...trade }
-      const currSymb = trade[symbolFieldName]
-      const symb = splitSymbolPairs(currSymb)[1]
 
       if (
-        !symb ||
-        typeof symb !== 'string' ||
         !Number.isFinite(execAmount) ||
         !Number.isFinite(execPrice)
       ) {

--- a/workers/loc.api/sync/traded.volume/index.js
+++ b/workers/loc.api/sync/traded.volume/index.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const TYPES = require('../../di/types')
+
+class TradedVolume {
+  constructor (
+    dao,
+    FOREX_SYMBS
+  ) {
+    this.dao = dao
+    this.FOREX_SYMBS = FOREX_SYMBS
+  }
+
+  // TODO:
+  async getTradedVolume (
+    {
+      auth = {},
+      params: {
+        timeframe = 'day',
+        start = 0,
+        end = Date.now(),
+        symbol
+      } = {}
+    } = {}
+  ) {}
+}
+
+decorate(injectable(), TradedVolume)
+decorate(inject(TYPES.DAO), TradedVolume, 0)
+decorate(inject(TYPES.FOREX_SYMBS), TradedVolume, 1)
+
+module.exports = TradedVolume


### PR DESCRIPTION
This PR adds a traded volume report in USD equivalent. Basic changes:
  - adds `getTradedVolume` method to the grenache service
  - adds `getTradedVolumeCsv` method to the grenache service
  - adds `convertManyByCandles` method to the `CurrencyConverter` service to convert currencies of data group doing one query to `DB` using the candles collection
  - adds corresponding test coverage

Request example to the `getTradedVolume` method:
```json
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "getTradedVolume",
    "params": {
    	"start": 1575158400000,
    	"end": 1575763200000,
    	"timeframe": "day",
    	"symbol": ["tLEOUSD", "tNEOUSD"]
    }
}
```

Response example:
```json
{
    "result": [
        {
            "mts": 1575676800000,
            "USD": 123
        },
        {
            "mts": 1575590400000,
            "USD": 321
        },
        {
            "mts": 1575417600000,
            "USD": 213
        }
    ],
    "id": null
}
```