### PR TITLE
Fix win/loss report

### DIFF
--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -134,7 +134,7 @@ class CurrencyConverter {
 
     const symbol = this._getPairFromPair(reqSymb)
     const { res } = await getDataFromApi(
-      this.rService._getPublicTrades.bind(this.rService),
+      (space, args) => this.rService._getPublicTrades.bind(this.rService)(args),
       {
         params: {
           symbol,

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -586,7 +586,7 @@ const _methodCollMap = new Map([
       sort: [['mts', -1]],
       groupResBy: ['wallet', 'currency'],
       subQuery: {
-        sort: [['mts', 1], ['id', 1]]
+        sort: [['mts', -1], ['id', -1]]
       },
       type: 'hidden:insertable:array:objects',
       model: { ..._models.get(TABLES_NAMES.LEDGERS) },


### PR DESCRIPTION
This PR fixes win/loss report, basic changes:
  - fixes public trades price getting in the currency converter
  - fixes subquery sorting for grouping wallets by timeframe