### PR TITLE
Add ability to specify path to sqlite db file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-reports-framework",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Bitfinex reports framework",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -78,6 +78,9 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
   init () {
     super.init()
 
+    const dbFolder = path.isAbsolute(argv.dbFolder)
+      ? argv.dbFolder
+      : path.join(this.ctx.root, argv.dbFolder)
     const conf = this.conf[this.group]
     const facs = []
 
@@ -95,7 +98,7 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
           `bfx-facs-db-${conf.dbDriver}`,
           'm0',
           'm0',
-          { name: 'sync' }
+          { name: 'sync', dbFolder }
         ]
       )
     }

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -22,6 +22,9 @@ const argv = require('yargs')
   .option('wsPort', {
     type: 'number'
   })
+  .option('grape', {
+    type: 'string'
+  })
   .help('help')
   .argv
 
@@ -36,6 +39,13 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
 
     this.appDeps.push(_appDeps)
     this.container.load(_appDeps)
+  }
+
+  getGrcConf () {
+    return {
+      ...super.getGrcConf(),
+      grape: argv.grape
+    }
   }
 
   getApiConf () {


### PR DESCRIPTION
This PR adds abilities to specify path to sqlite db file and override grape address

**Depends** on these PRs:
  - [bfx-report#160](https://github.com/bitfinexcom/bfx-report/pull/160)
  - [bfx-facs-grc#14](https://github.com/bitfinexcom/bfx-facs-grc/pull/14)
  - [bfx-facs-db-sqlite#19](https://github.com/bitfinexcom/bfx-facs-db-sqlite/pull/19)