### PR TITLE
Fix name typo for performing loan csv method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-reports-framework",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Bitfinex reports framework",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -78,6 +78,9 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
   init () {
     super.init()
 
+    const dbFolder = path.isAbsolute(argv.dbFolder)
+      ? argv.dbFolder
+      : path.join(this.ctx.root, argv.dbFolder)
     const conf = this.conf[this.group]
     const facs = []
 
@@ -95,7 +98,7 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
           `bfx-facs-db-${conf.dbDriver}`,
           'm0',
           'm0',
-          { name: 'sync' }
+          { name: 'sync', dbFolder }
         ]
       )
     }

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -22,6 +22,9 @@ const argv = require('yargs')
   .option('wsPort', {
     type: 'number'
   })
+  .option('grape', {
+    type: 'string'
+  })
   .help('help')
   .argv
 
@@ -36,6 +39,13 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
 
     this.appDeps.push(_appDeps)
     this.container.load(_appDeps)
+  }
+
+  getGrcConf () {
+    return {
+      ...super.getGrcConf(),
+      grape: argv.grape
+    }
   }
 
   getApiConf () {

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -467,7 +467,7 @@ class CsvJobData extends BaseCsvJobData {
     return jobData
   }
 
-  async getPerformingLoanCsvCsvJobData (
+  async getPerformingLoanCsvJobData (
     args,
     uId,
     uInfo

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -980,7 +980,7 @@ class FrameworkReportService extends ReportService {
   getPerformingLoanCsv (space, args, cb) {
     return this._responder(() => {
       return this._generateCsv(
-        'getPerformingLoanCsvCsvJobData',
+        'getPerformingLoanCsvJobData',
         args
       )
     }, 'getPerformingLoanCsv', cb)


### PR DESCRIPTION
This PR fixes name typo for the `getPerformingLoanCsv` method to generate csv in the `getMultipleCsv` method