### PR TITLE
Add currencies synonymous

### DIFF
--- a/test/helpers/helpers.worker.js
+++ b/test/helpers/helpers.worker.js
@@ -20,6 +20,7 @@ const startWorkers = (
     wsPort: 23381,
     syncMode: true,
     isSchedulerEnabled: true,
+    schedulerRule: '0 */5 * * *',
     ...conf
   }
 

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -29,6 +29,9 @@ const argv = require('yargs')
     type: 'string',
     default: 'secretKey'
   })
+  .option('schedulerRule', {
+    type: 'string'
+  })
   .help('help')
   .argv
 
@@ -83,7 +86,8 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
       'isSchedulerEnabled',
       'dbDriver',
       'wsPort',
-      'secretKey'
+      'secretKey',
+      'schedulerRule'
     ]
   ) {
     super.setArgsOfCommandLineToConf()
@@ -140,11 +144,16 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
       return
     }
 
-    const { rule } = require(path.join(
-      this.ctx.root,
-      'config',
-      'schedule.json'
-    ))
+    const { rule } = (
+      conf.schedulerRule &&
+      typeof conf.schedulerRule === 'string'
+    )
+      ? { rule: conf.schedulerRule }
+      : require(path.join(
+        this.ctx.root,
+        'config',
+        'schedule.json'
+      ))
     const name = 'sync'
 
     this.scheduler_sync.add(name, () => sync.start(), rule)

--- a/workers/loc.api/sync/balance.history/index.js
+++ b/workers/loc.api/sync/balance.history/index.js
@@ -149,7 +149,8 @@ class BalanceHistory {
     candles,
     mts,
     timeframe,
-    symb
+    symb,
+    currenciesSynonymous
   ) {
     const mtsMoment = moment.utc(mts)
 
@@ -168,7 +169,7 @@ class BalanceHistory {
     const price = this.currencyConverter.getPriceFromData(
       symb,
       _mts,
-      { candles }
+      { candles, currenciesSynonymous }
     )
 
     return price
@@ -177,7 +178,8 @@ class BalanceHistory {
   _getWalletsByTimeframe (
     firstWallets,
     candles,
-    timeframe
+    timeframe,
+    currenciesSynonymous
   ) {
     let prevRes = { ...firstWallets }
 
@@ -205,7 +207,8 @@ class BalanceHistory {
             candles,
             mts,
             timeframe,
-            `t${currency}USD`
+            `t${currency}USD`,
+            currenciesSynonymous
           )
 
         if (!_isForexSymb && !Number.isFinite(price)) {
@@ -239,7 +242,8 @@ class BalanceHistory {
         res,
         candles,
         mts,
-        timeframe
+        timeframe,
+        currenciesSynonymous
       )
     }
   }
@@ -248,7 +252,8 @@ class BalanceHistory {
     obj,
     candles,
     mts,
-    timeframe
+    timeframe,
+    currenciesSynonymous
   ) {
     const dataArr = Object.entries(obj)
 
@@ -266,7 +271,8 @@ class BalanceHistory {
           candles,
           mts,
           timeframe,
-          `t${symb}USD`
+          `t${symb}USD`,
+          currenciesSynonymous
         )
       }
 
@@ -417,6 +423,9 @@ class BalanceHistory {
       true
     )
 
+    const currenciesSynonymous = await this.currencyConverter
+      .getCurrenciesSynonymous()
+
     const res = await calcGroupedData(
       {
         walletsGroupedByTimeframe,
@@ -426,7 +435,8 @@ class BalanceHistory {
       this._getWalletsByTimeframe(
         firstWalletsGroupedByCurrency,
         candles,
-        timeframe
+        timeframe,
+        currenciesSynonymous
       ),
       true
     )

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v12.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v12.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+const { getSqlArrToModifyColumns } = require('./helpers')
+
+class MigrationV11 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'ALTER TABLE currencies ADD COLUMN walletFx TEXT'
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  beforeDown () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      ...getSqlArrToModifyColumns(
+        'currencies',
+        {
+          _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+          id: 'VARCHAR(255)',
+          name: 'VARCHAR(255)',
+          pool: 'VARCHAR(255)',
+          explorer: 'TEXT'
+        }
+      )
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  afterDown () { return this.dao.enableForeignKeys() }
+}
+
+module.exports = MigrationV11

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -1090,7 +1090,36 @@ class DataInserter extends EventEmitter {
       return
     }
 
-    const _collСonfig = uniqueLedgersSymbs.map(({ currency }) => {
+    const currenciesSynonymous = await this.currencyConverter
+      .getCurrenciesSynonymous()
+
+    const uniqueSymbs = uniqueLedgersSymbs.reduce((accum, ledger) => {
+      const { currency } = { ...ledger }
+
+      if (!currency) {
+        return accum
+      }
+
+      accum.push(currency)
+
+      const synonymous = currenciesSynonymous.get(currency)
+
+      if (!synonymous) {
+        return accum
+      }
+
+      const uniqueSynonymous = synonymous
+        .filter(([syn]) => (
+          accum.every((symb) => symb !== syn)
+        ))
+        .map(([syn]) => syn)
+
+      accum.push(...uniqueSynonymous)
+
+      return accum
+    }, [])
+
+    const _collСonfig = uniqueSymbs.map((currency) => {
       const _currency = typeof currency === 'string'
         ? currency.replace(/F0$/i, '')
         : currency

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -7,7 +7,7 @@
  * in the `workers/loc.api/sync/dao/db-migrations/sqlite-migrations` folder,
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
-const SUPPORTED_DB_VERSION = 11
+const SUPPORTED_DB_VERSION = 12
 
 const { cloneDeep, omit } = require('lodash')
 
@@ -458,7 +458,8 @@ const _models = new Map([
       id: 'VARCHAR(255)',
       name: 'VARCHAR(255)',
       pool: 'VARCHAR(255)',
-      explorer: 'TEXT'
+      explorer: 'TEXT',
+      walletFx: 'TEXT'
     }
   ],
   [


### PR DESCRIPTION
This PR adds currencies synonymous to allow to convert currencies to USD when currency is not found in candles collection

**Depends** on these PRs:
  - https://github.com/bitfinexcom/bfx-report/pull/181
  - https://github.com/bitfinexcom/bfx-api-node-models/pull/53
  - https://github.com/bitfinexcom/bfx-api-node-rest/pull/72