### PR TITLE
Add min and max clamps to status messages derivatives

### DIFF
--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -1978,7 +1978,9 @@ module.exports = (
       'priceSpot',
       'fundBal',
       'fundingAccrued',
-      'fundingStep'
+      'fundingStep',
+      'clampMin',
+      'clampMax'
     ])
   })
 

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v15.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v15.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+const { getSqlArrToModifyColumns } = require('./helpers')
+
+class MigrationV15 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'ALTER TABLE statusMessages ADD COLUMN clampMin DECIMAL(22,12)',
+      'ALTER TABLE statusMessages ADD COLUMN clampMax DECIMAL(22,12)'
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  beforeDown () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      ...getSqlArrToModifyColumns(
+        'statusMessages',
+        {
+          _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+          key: 'VARCHAR(255)',
+          timestamp: 'BIGINT',
+          price: 'DECIMAL(22,12)',
+          priceSpot: 'DECIMAL(22,12)',
+          fundBal: 'DECIMAL(22,12)',
+          fundingAccrued: 'DECIMAL(22,12)',
+          fundingStep: 'DECIMAL(22,12)',
+          _type: 'VARCHAR(255)'
+        }
+      )
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  afterDown () { return this.dao.enableForeignKeys() }
+}
+
+module.exports = MigrationV15

--- a/workers/loc.api/sync/schema/index.js
+++ b/workers/loc.api/sync/schema/index.js
@@ -7,7 +7,7 @@
  * in the `workers/loc.api/sync/dao/db-migrations/sqlite-migrations` folder,
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
-const SUPPORTED_DB_VERSION = 14
+const SUPPORTED_DB_VERSION = 15
 
 const TABLES_NAMES = require('./tables-names')
 const ALLOWED_COLLS = require('./allowed.colls')
@@ -400,6 +400,8 @@ const _models = new Map([
       fundBal: 'DECIMAL(22,12)',
       fundingAccrued: 'DECIMAL(22,12)',
       fundingStep: 'DECIMAL(22,12)',
+      clampMin: 'DECIMAL(22,12)',
+      clampMax: 'DECIMAL(22,12)',
       _type: 'VARCHAR(255)'
     }
   ],


### PR DESCRIPTION
This PR adds `clampMin` and `clampMax` fields to status messages derivatives for the sync mode. Basic changes:
  - adds  `clampMin` and `clampMax` fields to the `statusMessages` table of the db schema
  - adds v15 db migration
  - improves status messages derivatives test coverage

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/194