### PR TITLE
Return sub-users emails by getUsers method

### DIFF
--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -326,6 +326,11 @@ module.exports = (
       assert.isString(user.email)
       assert.isBoolean(user.isSubAccount)
       assert.isBoolean(user.isNotProtected)
+      assert.isArray(user.subUsers)
+
+      user.subUsers.forEach((subUser) => {
+        assert.isString(subUser.email)
+      })
     })
   })
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -137,7 +137,17 @@ class FrameworkReportService extends ReportService {
     return this._responder(async () => {
       return this._authenticator.getUsers(
         { isSubUser: false },
-        { projection: ['email', 'isSubAccount', 'isNotProtected'] }
+        {
+          isFilledSubUsers: true,
+          isAppliedProjectionToSubUser: true,
+          subUsersProjection: ['email'],
+          projection: [
+            'email',
+            'isSubAccount',
+            'isNotProtected',
+            'subUsers'
+          ]
+        }
       )
     }, 'getUsers', cb)
   }

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -478,7 +478,8 @@ class Authenticator {
       isReturnedPassword,
       isSubUser = false,
       isNotInTrans,
-      isAppliedProjectionToSubUser
+      isAppliedProjectionToSubUser,
+      subUsersProjection
     } = { ...params }
 
     if (
@@ -513,7 +514,10 @@ class Authenticator {
       return this.pickProps(
         user,
         projection,
-        isAppliedProjectionToSubUser
+        {
+          isAppliedProjectionToSubUser,
+          subUsersProjection
+        }
       )
     }
     if (
@@ -538,7 +542,10 @@ class Authenticator {
       return this.pickProps(
         session,
         projection,
-        isAppliedProjectionToSubUser
+        {
+          isAppliedProjectionToSubUser,
+          subUsersProjection
+        }
       )
     }
 
@@ -580,14 +587,18 @@ class Authenticator {
       isFilledSubUsers,
       projection,
       password,
-      isAppliedProjectionToSubUser
+      isAppliedProjectionToSubUser,
+      subUsersProjection
     } = { ...params }
 
     const _user = await this.dao.getUser(filter, params)
     const user = this.pickProps(
       _user,
       projection,
-      isAppliedProjectionToSubUser
+      {
+        isAppliedProjectionToSubUser,
+        subUsersProjection
+      }
     )
 
     if (
@@ -621,7 +632,8 @@ class Authenticator {
       password,
       emailPasswordsMap,
       projection,
-      isAppliedProjectionToSubUser
+      isAppliedProjectionToSubUser,
+      subUsersProjection
     } = { ...params }
     const _emailPasswordsMap = Array.isArray(emailPasswordsMap)
       ? emailPasswordsMap
@@ -642,7 +654,10 @@ class Authenticator {
     const users = this.pickProps(
       _users,
       projection,
-      isAppliedProjectionToSubUser
+      {
+        isAppliedProjectionToSubUser,
+        subUsersProjection
+      }
     )
 
     if (
@@ -828,13 +843,22 @@ class Authenticator {
     return username
   }
 
-  pickProps (data, props, isAppliedProjectionToSubUser) {
+  pickProps (
+    data,
+    projection,
+    opts
+  ) {
     if (
-      !Array.isArray(props) ||
-      props.length === 0
+      !Array.isArray(projection) ||
+      projection.length === 0
     ) {
       return data
     }
+
+    const {
+      isAppliedProjectionToSubUser,
+      subUsersProjection = projection
+    } = { ...opts }
 
     const isArray = Array.isArray(data)
     const dataArr = isArray ? data : [data]
@@ -846,10 +870,12 @@ class Authenticator {
 
       if (
         !isAppliedProjectionToSubUser ||
+        !Array.isArray(subUsersProjection) ||
+        subUsersProjection.length === 0 ||
         !Array.isArray(item.subUsers) ||
         item.subUsers.length === 0
       ) {
-        return pick(item, props)
+        return pick(item, projection)
       }
 
       const subUsers = item.subUsers.map((subUser) => {
@@ -857,10 +883,10 @@ class Authenticator {
           return subUser
         }
 
-        return pick(subUser, props)
+        return pick(subUser, subUsersProjection)
       })
 
-      return pick({ ...item, subUsers }, props)
+      return pick({ ...item, subUsers }, projection)
     })
 
     return isArray ? res : res[0]


### PR DESCRIPTION
This PR adds an ability to return sub-users emails by the `getUsers` method to improve UI/UX flow for recovering a password. Basic changes:
  - improves picking props for sub-users
  - returns sub-users emails by `getUsers` method
  - improves corresponding test coverage

Request example:
```
{
    "method": "getUsers"
}
```

Response example:
```
{
    "result": [
        {
            "email": "user@mail.com",
            "isSubAccount": false,
            "isNotProtected": false,
            "subUsers": []
        },
        {
            "email": "user@mail.com",
            "isSubAccount": true,
            "isNotProtected": false,
            "subUsers": [
                {
                    "email": "another-user@mail.com"
                },
                {
                    "email": "user@mail.com"
                }
            ]
        }
    ],
    "id": null
}
```