### PR TITLE
Run vacuum command at startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "moment": "^2.24.0",
     "scrypt-js": "^3.0.0",
     "uuid": "^8.0.0",
-    "yargs": "^13.2.4"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -74,6 +74,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -93,10 +94,8 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
-    assert.isOk(
-      typeof res.body.result === 'string' ||
-      typeof res.body.result === 'number'
-    )
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
   })
 
   it('it should be successfully performed by the syncNow method', async function () {

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -350,6 +350,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -369,10 +370,8 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
-    assert.isOk(
-      typeof res.body.result === 'string' ||
-      typeof res.body.result === 'number'
-    )
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
   })
 
   it('it should be successfully performed by the isSchedulerEnabled method', async function () {
@@ -443,6 +442,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -502,6 +502,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -583,6 +584,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -642,6 +644,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -725,6 +728,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -805,6 +809,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -914,6 +919,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -5,7 +5,8 @@ const {
   checkParamsAuth,
   tryParseJSON,
   collObjToArr,
-  getDateString
+  getDateString,
+  isNotSyncRequired
 } = require('./utils')
 const {
   isEnotfoundError,
@@ -23,6 +24,7 @@ module.exports = {
   tryParseJSON,
   collObjToArr,
   getDateString,
+  isNotSyncRequired,
   isEnotfoundError,
   isEaiAgainError,
   isSubAccountApiKeys,

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -62,9 +62,20 @@ const getDateString = (mc) => {
   return new Date(mc).toDateString().split(' ').join('-')
 }
 
+const isNotSyncRequired = (args) => {
+  return (
+    args &&
+    typeof args === 'object' &&
+    args.params &&
+    typeof args.params === 'object' &&
+    args.params.isNotSyncRequired
+  )
+}
+
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
   collObjToArr,
-  getDateString
+  getDateString,
+  isNotSyncRequired
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -21,6 +21,7 @@ const {
 const {
   checkParams,
   checkParamsAuth,
+  isNotSyncRequired,
   isEnotfoundError,
   isEaiAgainError,
   collObjToArr,
@@ -220,6 +221,11 @@ class FrameworkReportService extends ReportService {
         this._TABLES_NAMES.SYNC_MODE,
         { isEnable: true }
       )
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
       await this._sync.start(true)
 
       return true
@@ -281,8 +287,13 @@ class FrameworkReportService extends ReportService {
         { isEnable: true }
       )
 
-      return this._sync
-        .start(true, this._ALLOWED_COLLS.ALL)
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync.start(true)
+
+      return true
     }, 'enableScheduler', args, cb)
   }
 
@@ -378,7 +389,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('publicTradesConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.PUBLIC_TRADES)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.PUBLIC_TRADES)
 
       return true
     }, 'editPublicTradesConf', args, cb)
@@ -390,7 +407,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('tickersHistoryConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.TICKERS_HISTORY)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.TICKERS_HISTORY)
 
       return true
     }, 'editTickersHistoryConf', args, cb)
@@ -402,7 +425,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('statusMessagesConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.STATUS_MESSAGES)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.STATUS_MESSAGES)
 
       return true
     }, 'editStatusMessagesConf', args, cb)
@@ -414,7 +443,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('candlesConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.CANDLES)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.CANDLES)
 
       return true
     }, 'editCandlesConf', args, cb)
@@ -426,6 +461,11 @@ class FrameworkReportService extends ReportService {
 
       const syncedColls = await this._publicСollsСonfAccessors
         .editAllPublicСollsСonfs(args)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
       await this._sync.start(true, syncedColls)
 
       return true

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -496,6 +496,12 @@ class FrameworkReportService extends ReportService {
         return collObjToArr(res, field)
       })
 
+      const res = await Promise.all(promises)
+
+      if (res.some(isEmpty)) {
+        return super.getSymbols(space, args)
+      }
+
       const [
         symbols,
         futures,
@@ -503,16 +509,7 @@ class FrameworkReportService extends ReportService {
         mapSymbols,
         inactiveCurrencies,
         inactiveSymbols
-      ] = await Promise.all(promises)
-
-      if (
-        isEmpty(symbols) &&
-        isEmpty(futures) &&
-        isEmpty(currencies) &&
-        isEmpty(inactiveSymbols)
-      ) {
-        return super.getSymbols(space, args)
-      }
+      ] = res
 
       const pairs = [...symbols, ...futures]
 

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -213,6 +213,13 @@ class BetterSqliteDAO extends DAO {
     })
   }
 
+  _vacuum () {
+    return this.query({
+      action: MAIN_DB_WORKER_ACTIONS.RUN,
+      sql: 'VACUUM'
+    })
+  }
+
   optimize () {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
@@ -266,6 +273,7 @@ class BetterSqliteDAO extends DAO {
     await this._createTablesIfNotExists()
     await this._createIndexisIfNotExists()
     await this._createTriggerIfNotExists()
+    await this._vacuum()
     await this.setCurrDbVer(this.syncSchema.SUPPORTED_DB_VERSION)
   }
 

--- a/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { upperCase, snakeCase } = require('lodash')
+
+module.exports = (method) => {
+  const name = method.replace(/^[^A-Z]+/, '')
+  const upperCaseName = upperCase(name)
+  const snakeCaseName = snakeCase(upperCaseName)
+
+  return snakeCaseName
+}

--- a/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const { upperCase, snakeCase } = require('lodash')
+const { snakeCase } = require('lodash')
 
 module.exports = (method) => {
   const name = method.replace(/^[^A-Z]+/, '')
-  const upperCaseName = upperCase(name)
-  const snakeCaseName = snakeCase(upperCaseName)
+  const snakeCaseName = snakeCase(name)
+  const upperCaseName = snakeCaseName.toUpperCase()
 
-  return snakeCaseName
+  return upperCaseName
 }

--- a/workers/loc.api/sync/data.inserter/helpers/index.js
+++ b/workers/loc.api/sync/data.inserter/helpers/index.js
@@ -12,6 +12,7 @@ const {
   getAllowedCollsNames
 } = require('./utils')
 const getMethodArgMap = require('./get-method-arg-map')
+const getSyncCollName = require('./get-sync-coll-name')
 
 module.exports = {
   searchClosePriceAndSumAmount,
@@ -19,5 +20,6 @@ module.exports = {
   normalizeApiData,
   getAuthFromDb,
   getAllowedCollsNames,
-  getMethodArgMap
+  getMethodArgMap,
+  getSyncCollName
 }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -174,7 +174,7 @@ class DataInserter extends EventEmitter {
     await this.insertNewPublicDataToDb(progress)
 
     await this.wsEventEmitter
-      .emitSyncingStep(() => 'DB_PREPARATION')
+      .emitSyncingStep('DB_PREPARATION')
     await this._afterAllInserts()
 
     if (typeof this.dao.optimize === 'function') {
@@ -236,7 +236,7 @@ class DataInserter extends EventEmitter {
     }
 
     await this.wsEventEmitter
-      .emitSyncingStep(() => 'CHECKING_NEW_PUBLIC_DATA')
+      .emitSyncingStep('CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewPublicData()
     const size = methodCollMap.size
@@ -249,9 +249,8 @@ class DataInserter extends EventEmitter {
         return
       }
 
-      await this.wsEventEmitter.emitSyncingStep(
-        () => `SYNCING_${getSyncCollName(method)}`
-      )
+      await this.wsEventEmitter
+        .emitSyncingStep(`SYNCING_${getSyncCollName(method)}`)
 
       await this._updateApiDataArrObjTypeToDb(method, item)
       await this._updateApiDataArrTypeToDb(method, item)
@@ -281,11 +280,10 @@ class DataInserter extends EventEmitter {
       return userProgress
     }
 
-    await this.wsEventEmitter
-      .emitSyncingStepToOne(
-        () => 'CHECKING_NEW_PRIVATE_DATA',
-        auth
-      )
+    await this.wsEventEmitter.emitSyncingStepToOne(
+      'CHECKING_NEW_PRIVATE_DATA',
+      auth
+    )
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
@@ -299,7 +297,7 @@ class DataInserter extends EventEmitter {
       }
 
       await this.wsEventEmitter.emitSyncingStepToOne(
-        () => `SYNCING_${getSyncCollName(method)}`,
+        `SYNCING_${getSyncCollName(method)}`,
         auth
       )
 

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -27,7 +27,8 @@ const {
   normalizeApiData,
   getAuthFromDb,
   getAllowedCollsNames,
-  getMethodArgMap
+  getMethodArgMap,
+  getSyncCollName
 } = require('./helpers')
 const DataInserterHook = require('./hooks/data.inserter.hook')
 const {
@@ -58,7 +59,8 @@ class DataInserter extends EventEmitter {
     convertCurrencyHook,
     recalcSubAccountLedgersBalancesHook,
     dataChecker,
-    syncInterrupter
+    syncInterrupter,
+    wsEventEmitter
   ) {
     super()
 
@@ -74,6 +76,7 @@ class DataInserter extends EventEmitter {
     this.recalcSubAccountLedgersBalancesHook = recalcSubAccountLedgersBalancesHook
     this.dataChecker = dataChecker
     this.syncInterrupter = syncInterrupter
+    this.wsEventEmitter = wsEventEmitter
 
     this._asyncProgressHandlers = []
     this._auth = null
@@ -170,6 +173,8 @@ class DataInserter extends EventEmitter {
 
     await this.insertNewPublicDataToDb(progress)
 
+    await this.wsEventEmitter
+      .emitSyncingStep(() => 'DB_PREPARATION')
     await this._afterAllInserts()
 
     if (typeof this.dao.optimize === 'function') {
@@ -230,6 +235,8 @@ class DataInserter extends EventEmitter {
       return
     }
 
+    await this.wsEventEmitter
+      .emitSyncingStepToOne(() => 'CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewPublicData()
     const size = methodCollMap.size
@@ -241,6 +248,10 @@ class DataInserter extends EventEmitter {
       if (this._isInterrupted) {
         return
       }
+
+      await this.wsEventEmitter.emitSyncingStepToOne(
+        () => `SYNCING_${getSyncCollName(method)}`
+      )
 
       await this._updateApiDataArrObjTypeToDb(method, item)
       await this._updateApiDataArrTypeToDb(method, item)
@@ -270,6 +281,8 @@ class DataInserter extends EventEmitter {
       return userProgress
     }
 
+    await this.wsEventEmitter
+      .emitSyncingStepToOne(() => 'CHECKING_NEW_PRIVATE_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
@@ -281,6 +294,10 @@ class DataInserter extends EventEmitter {
       if (this._isInterrupted) {
         return userProgress
       }
+
+      await this.wsEventEmitter.emitSyncingStepToOne(
+        () => `SYNCING_${getSyncCollName(method)}`
+      )
 
       const { start } = schema
 
@@ -822,5 +839,6 @@ decorate(inject(TYPES.ConvertCurrencyHook), DataInserter, 8)
 decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 9)
 decorate(inject(TYPES.DataChecker), DataInserter, 10)
 decorate(inject(TYPES.SyncInterrupter), DataInserter, 11)
+decorate(inject(TYPES.WSEventEmitter), DataInserter, 12)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -236,7 +236,7 @@ class DataInserter extends EventEmitter {
     }
 
     await this.wsEventEmitter
-      .emitSyncingStepToOne(() => 'CHECKING_NEW_PUBLIC_DATA')
+      .emitSyncingStep(() => 'CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewPublicData()
     const size = methodCollMap.size
@@ -249,7 +249,7 @@ class DataInserter extends EventEmitter {
         return
       }
 
-      await this.wsEventEmitter.emitSyncingStepToOne(
+      await this.wsEventEmitter.emitSyncingStep(
         () => `SYNCING_${getSyncCollName(method)}`
       )
 
@@ -282,7 +282,10 @@ class DataInserter extends EventEmitter {
     }
 
     await this.wsEventEmitter
-      .emitSyncingStepToOne(() => 'CHECKING_NEW_PRIVATE_DATA')
+      .emitSyncingStepToOne(
+        () => 'CHECKING_NEW_PRIVATE_DATA',
+        auth
+      )
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
@@ -296,7 +299,8 @@ class DataInserter extends EventEmitter {
       }
 
       await this.wsEventEmitter.emitSyncingStepToOne(
-        () => `SYNCING_${getSyncCollName(method)}`
+        () => `SYNCING_${getSyncCollName(method)}`,
+        auth
       )
 
       const { start } = schema

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -265,10 +265,7 @@ class WSTransport {
 
       try {
         if (
-          (
-            typeof handler !== 'function' &&
-            handler === null
-          ) ||
+          handler === null ||
           (
             isEmittedToActiveUsers &&
             !this._isActiveUser(user)

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -29,6 +29,32 @@ class WSEventEmitter {
     )
   }
 
+  emitSyncingStep (
+    handler = () => {}
+  ) {
+    return this.wsTransport.sendToActiveUsers(
+      handler,
+      'emitSyncingStep'
+    )
+  }
+
+  emitSyncingStepToOne (
+    handler = () => {},
+    auth = {}
+  ) {
+    return this.emitSyncingStep((user, ...args) => {
+      if (
+        !auth ||
+        typeof auth !== 'object' ||
+        user._id !== auth._id
+      ) {
+        return
+      }
+
+      return handler(user, ...args)
+    })
+  }
+
   async emitRedirectingRequestsStatusToApi (
     handler = () => {}
   ) {

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -42,7 +42,7 @@ class WSEventEmitter {
     handler = () => {},
     auth = {}
   ) {
-    return this.emitSyncingStep((user, ...args) => {
+    return this.emitSyncingStep(async (user, ...args) => {
       if (
         !auth ||
         typeof auth !== 'object' ||
@@ -51,7 +51,9 @@ class WSEventEmitter {
         return
       }
 
-      return handler(user, ...args)
+      return typeof handler === 'function'
+        ? await handler(user, ...args)
+        : handler
     })
   }
 


### PR DESCRIPTION
This PR runs the `VACUUM` command at the startup of the app. The database file might be larger than strictly necessary, running `VACUUM` to rebuild the database reclaims this space and reduces the size of the database file, check the doc https://sqlite.org/lang_vacuum.html