### PR TITLE
Fix login for unprotected sub-account

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "moment": "^2.24.0",
     "scrypt-js": "^3.0.0",
     "uuid": "^8.0.0",
-    "yargs": "^13.2.4"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -74,6 +74,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -93,10 +94,8 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
-    assert.isOk(
-      typeof res.body.result === 'string' ||
-      typeof res.body.result === 'number'
-    )
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
   })
 
   it('it should be successfully performed by the syncNow method', async function () {

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -334,6 +334,26 @@ module.exports = (
     })
   })
 
+  it('it should be successfully performed by the haveCollsBeenSyncedAtLeastOnce method, returns false', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'haveCollsBeenSyncedAtLeastOnce',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
+    assert.isNotOk(res.body.result)
+  })
+
   it('it should be successfully performed by the enableSyncMode method', async function () {
     this.timeout(5000)
 
@@ -420,6 +440,26 @@ module.exports = (
 
       await delay()
     }
+  })
+
+  it('it should be successfully performed by the haveCollsBeenSyncedAtLeastOnce method, returns true', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'haveCollsBeenSyncedAtLeastOnce',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
   })
 
   it('it should be successfully performed by the editPublicTradesConf method, where an object is passed', async function () {

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -350,6 +350,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -369,10 +370,8 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
-    assert.isOk(
-      typeof res.body.result === 'string' ||
-      typeof res.body.result === 'number'
-    )
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
   })
 
   it('it should be successfully performed by the isSchedulerEnabled method', async function () {
@@ -443,6 +442,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -502,6 +502,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -583,6 +584,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -642,6 +644,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -725,6 +728,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -805,6 +809,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -914,6 +919,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -29,8 +29,7 @@ const argv = require('yargs')
     type: 'string'
   })
   .option('secretKey', {
-    type: 'string',
-    default: 'secretKey'
+    type: 'string'
   })
   .option('schedulerRule', {
     type: 'string'

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -26,6 +26,7 @@ const syncSchema = require('../sync/schema')
 const Sync = require('../sync')
 const SyncInterrupter = require('../sync/sync.interrupter')
 const SyncQueue = require('../sync/sync.queue')
+const SyncCollsManager = require('../sync/sync.colls.manager')
 const {
   redirectRequestsToApi,
   FOREX_SYMBS
@@ -241,6 +242,9 @@ module.exports = ({
       .to(RecalcSubAccountLedgersBalancesHook)
     bind(TYPES.SyncQueue)
       .to(SyncQueue)
+      .inSingletonScope()
+    bind(TYPES.SyncCollsManager)
+      .to(SyncCollsManager)
       .inSingletonScope()
     bind(TYPES.Sync)
       .to(Sync)

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -119,7 +119,8 @@ module.exports = ({
           ['_positionsAudit', TYPES.PositionsAudit],
           ['_orderTrades', TYPES.OrderTrades],
           ['_authenticator', TYPES.Authenticator],
-          ['_privResponder', TYPES.PrivResponder]
+          ['_privResponder', TYPES.PrivResponder],
+          ['_syncCollsManager', TYPES.SyncCollsManager]
         ]
       })
     rebind(TYPES.RServiceDepsSchemaAliase)

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -54,5 +54,6 @@ module.exports = {
   Crypto: Symbol.for('Crypto'),
   Authenticator: Symbol.for('Authenticator'),
   PrivResponder: Symbol.for('PrivResponder'),
-  SyncInterrupter: Symbol.for('SyncInterrupter')
+  SyncInterrupter: Symbol.for('SyncInterrupter'),
+  SyncCollsManager: Symbol.for('SyncCollsManager')
 }

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -5,7 +5,8 @@ const {
   checkParamsAuth,
   tryParseJSON,
   collObjToArr,
-  getDateString
+  getDateString,
+  isNotSyncRequired
 } = require('./utils')
 const {
   isEnotfoundError,
@@ -23,6 +24,7 @@ module.exports = {
   tryParseJSON,
   collObjToArr,
   getDateString,
+  isNotSyncRequired,
   isEnotfoundError,
   isEaiAgainError,
   isSubAccountApiKeys,

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -62,9 +62,20 @@ const getDateString = (mc) => {
   return new Date(mc).toDateString().split(' ').join('-')
 }
 
+const isNotSyncRequired = (args) => {
+  return (
+    args &&
+    typeof args === 'object' &&
+    args.params &&
+    typeof args.params === 'object' &&
+    args.params.isNotSyncRequired
+  )
+}
+
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
   collObjToArr,
-  getDateString
+  getDateString,
+  isNotSyncRequired
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -21,6 +21,7 @@ const {
 const {
   checkParams,
   checkParamsAuth,
+  isNotSyncRequired,
   isEnotfoundError,
   isEaiAgainError,
   collObjToArr,
@@ -220,6 +221,11 @@ class FrameworkReportService extends ReportService {
         this._TABLES_NAMES.SYNC_MODE,
         { isEnable: true }
       )
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
       await this._sync.start(true)
 
       return true
@@ -281,8 +287,13 @@ class FrameworkReportService extends ReportService {
         { isEnable: true }
       )
 
-      return this._sync
-        .start(true, this._ALLOWED_COLLS.ALL)
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync.start(true)
+
+      return true
     }, 'enableScheduler', args, cb)
   }
 
@@ -378,7 +389,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('publicTradesConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.PUBLIC_TRADES)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.PUBLIC_TRADES)
 
       return true
     }, 'editPublicTradesConf', args, cb)
@@ -390,7 +407,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('tickersHistoryConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.TICKERS_HISTORY)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.TICKERS_HISTORY)
 
       return true
     }, 'editTickersHistoryConf', args, cb)
@@ -402,7 +425,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('statusMessagesConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.STATUS_MESSAGES)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.STATUS_MESSAGES)
 
       return true
     }, 'editStatusMessagesConf', args, cb)
@@ -414,7 +443,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('candlesConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.CANDLES)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.CANDLES)
 
       return true
     }, 'editCandlesConf', args, cb)
@@ -426,6 +461,11 @@ class FrameworkReportService extends ReportService {
 
       const syncedColls = await this._publicСollsСonfAccessors
         .editAllPublicСollsСonfs(args)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
       await this._sync.start(true, syncedColls)
 
       return true

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -338,6 +338,13 @@ class FrameworkReportService extends ReportService {
     }, 'getSyncProgress', args, cb)
   }
 
+  haveCollsBeenSyncedAtLeastOnce (space, args, cb) {
+    return this._privResponder(() => {
+      return this._syncCollsManager
+        .haveCollsBeenSyncedAtLeastOnce(args)
+    }, 'haveCollsBeenSyncedAtLeastOnce', args, cb)
+  }
+
   syncNow (space, args = {}, cb) {
     return this._privResponder(() => {
       const { params } = { ...args }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -496,6 +496,12 @@ class FrameworkReportService extends ReportService {
         return collObjToArr(res, field)
       })
 
+      const res = await Promise.all(promises)
+
+      if (res.some(isEmpty)) {
+        return super.getSymbols(space, args)
+      }
+
       const [
         symbols,
         futures,
@@ -503,16 +509,7 @@ class FrameworkReportService extends ReportService {
         mapSymbols,
         inactiveCurrencies,
         inactiveSymbols
-      ] = await Promise.all(promises)
-
-      if (
-        isEmpty(symbols) &&
-        isEmpty(futures) &&
-        isEmpty(currencies) &&
-        isEmpty(inactiveSymbols)
-      ) {
-        return super.getSymbols(space, args)
-      }
+      ] = res
 
       const pairs = [...symbols, ...futures]
 

--- a/workers/loc.api/sync/authenticator/helpers/pick-session-props.js
+++ b/workers/loc.api/sync/authenticator/helpers/pick-session-props.js
@@ -4,7 +4,7 @@ const pickProps = require('./pick-props')
 
 module.exports = (session, isReturnedPassword) => {
   const passwordProp = isReturnedPassword
-    ? ['password']
+    ? ['password', 'isNotProtected']
     : []
   const allowedProps = [
     '_id',

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -213,6 +213,13 @@ class BetterSqliteDAO extends DAO {
     })
   }
 
+  _vacuum () {
+    return this.query({
+      action: MAIN_DB_WORKER_ACTIONS.RUN,
+      sql: 'VACUUM'
+    })
+  }
+
   optimize () {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
@@ -266,6 +273,7 @@ class BetterSqliteDAO extends DAO {
     await this._createTablesIfNotExists()
     await this._createIndexisIfNotExists()
     await this._createTriggerIfNotExists()
+    await this._vacuum()
     await this.setCurrDbVer(this.syncSchema.SUPPORTED_DB_VERSION)
   }
 

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v22.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v22.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+const { getSqlArrToModifyColumns } = require('./helpers')
+
+class MigrationV22 extends AbstractMigration {
+  /**
+   * @override
+   */
+  before () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'DROP INDEX IF EXISTS completedOnFirstSyncColls_collName_user_id',
+
+      'ALTER TABLE completedOnFirstSyncColls ADD COLUMN mts BIGINT',
+      'ALTER TABLE completedOnFirstSyncColls ADD COLUMN subUserId INT',
+
+      ...getSqlArrToModifyColumns(
+        'completedOnFirstSyncColls',
+        {
+          _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+          collName: 'VARCHAR(255) NOT NULL',
+          mts: 'BIGINT',
+          subUserId: 'INT',
+          user_id: 'INT',
+          __constraints__: [
+            `CONSTRAINT completedOnFirstSyncColls_fk_user_id
+              FOREIGN KEY (user_id)
+              REFERENCES users(_id)
+              ON UPDATE CASCADE
+              ON DELETE CASCADE`,
+            `CONSTRAINT completedOnFirstSyncColls_fk_subUserId
+              FOREIGN KEY (subUserId)
+              REFERENCES users(_id)
+              ON UPDATE CASCADE
+              ON DELETE CASCADE`
+          ]
+        }
+      ),
+
+      `CREATE UNIQUE INDEX completedOnFirstSyncColls_collName
+        ON completedOnFirstSyncColls (collName)
+        WHERE user_id IS NULL`,
+      `CREATE UNIQUE INDEX completedOnFirstSyncColls_user_id_collName
+        ON completedOnFirstSyncColls (user_id, collName)
+        WHERE user_id IS NOT NULL AND subUserId IS NULL`,
+      `CREATE UNIQUE INDEX completedOnFirstSyncColls_user_id_subUserId_collName
+        ON completedOnFirstSyncColls (user_id, subUserId, collName)
+        WHERE user_id IS NOT NULL AND subUserId IS NOT NULL`
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      'DROP INDEX IF EXISTS completedOnFirstSyncColls_collName',
+      'DROP INDEX IF EXISTS completedOnFirstSyncColls_user_id_collName',
+      'DROP INDEX IF EXISTS completedOnFirstSyncColls_user_id_subUserId_collName',
+
+      ...getSqlArrToModifyColumns(
+        'completedOnFirstSyncColls',
+        {
+          _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+          collName: 'VARCHAR(255)',
+          user_id: 'INT NOT NULL',
+          __constraints__: `CONSTRAINT completedOnFirstSyncColls_fk_user_id
+            FOREIGN KEY(user_id)
+            REFERENCES users(_id)
+            ON UPDATE CASCADE
+            ON DELETE CASCADE`
+        }
+      ),
+
+      `CREATE UNIQUE INDEX completedOnFirstSyncColls_collName_user_id
+        ON completedOnFirstSyncColls (collName, user_id)`
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  after () { return this.dao.enableForeignKeys() }
+}
+
+module.exports = MigrationV22

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v22.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v22.js
@@ -74,6 +74,17 @@ class MigrationV22 extends AbstractMigration {
           SELECT '_getChangeLogs' AS collName, subUserId, user_id FROM changeLogs
         ) WHERE subUserId IS NOT NULL`,
 
+      // Add public collections entries
+      `INSERT OR REPLACE INTO completedOnFirstSyncColls
+        (collName)
+        SELECT '_getSymbols' AS collName FROM symbols UNION
+        SELECT '_getMapSymbols' AS collName FROM mapSymbols UNION
+        SELECT '_getInactiveCurrencies' AS collName FROM inactiveCurrencies UNION
+        SELECT '_getInactiveSymbols' AS collName FROM inactiveSymbols UNION
+        SELECT '_getFutures' AS collName FROM futures UNION
+        SELECT '_getCurrencies' AS collName FROM currencies UNION
+        SELECT '_getCandles' AS collName FROM candles`,
+
       // Update private collections
       // Get mts from ledgers or logins to have
       // an approximate last sync start-up time

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -45,7 +45,8 @@ class DataChecker {
     ALLOWED_COLLS,
     FOREX_SYMBS,
     currencyConverter,
-    syncInterrupter
+    syncInterrupter,
+    syncCollsManager
   ) {
     this.rService = rService
     this.dao = dao
@@ -55,6 +56,7 @@ class DataChecker {
     this.FOREX_SYMBS = FOREX_SYMBS
     this.currencyConverter = currencyConverter
     this.syncInterrupter = syncInterrupter
+    this.syncCollsManager = syncCollsManager
 
     this._methodCollMap = new Map()
 
@@ -191,15 +193,13 @@ class DataChecker {
       startConf.currStart = lastDateInDb + 1
     }
 
-    const completedColl = await this.dao.getElemInCollBy(
-      this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
-      {
-        user_id: _id,
+    const hasCollBeenSyncedAtLeastOnce = await this.syncCollsManager
+      .hasCollBeenSyncedAtLeastOnce({
+        userId: _id,
         collName: method
-      }
-    )
+      })
 
-    if (!isEmpty(completedColl)) {
+    if (hasCollBeenSyncedAtLeastOnce) {
       pushConfigurableDataStartConf(
         schema,
         ALL_SYMBOLS_TO_SYNC,
@@ -714,5 +714,6 @@ decorate(inject(TYPES.ALLOWED_COLLS), DataChecker, 4)
 decorate(inject(TYPES.FOREX_SYMBS), DataChecker, 5)
 decorate(inject(TYPES.CurrencyConverter), DataChecker, 6)
 decorate(inject(TYPES.SyncInterrupter), DataChecker, 7)
+decorate(inject(TYPES.SyncCollsManager), DataChecker, 8)
 
 module.exports = DataChecker

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -196,6 +196,7 @@ class DataChecker {
     const hasCollBeenSyncedAtLeastOnce = await this.syncCollsManager
       .hasCollBeenSyncedAtLeastOnce({
         userId: _id,
+        subUserId,
         collName: method
       })
 

--- a/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { upperCase, snakeCase } = require('lodash')
+
+module.exports = (method) => {
+  const name = method.replace(/^[^A-Z]+/, '')
+  const upperCaseName = upperCase(name)
+  const snakeCaseName = snakeCase(upperCaseName)
+
+  return snakeCaseName
+}

--- a/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const { upperCase, snakeCase } = require('lodash')
+const { snakeCase } = require('lodash')
 
 module.exports = (method) => {
   const name = method.replace(/^[^A-Z]+/, '')
-  const upperCaseName = upperCase(name)
-  const snakeCaseName = snakeCase(upperCaseName)
+  const snakeCaseName = snakeCase(name)
+  const upperCaseName = snakeCaseName.toUpperCase()
 
-  return snakeCaseName
+  return upperCaseName
 }

--- a/workers/loc.api/sync/data.inserter/helpers/index.js
+++ b/workers/loc.api/sync/data.inserter/helpers/index.js
@@ -12,6 +12,7 @@ const {
   getAllowedCollsNames
 } = require('./utils')
 const getMethodArgMap = require('./get-method-arg-map')
+const getSyncCollName = require('./get-sync-coll-name')
 
 module.exports = {
   searchClosePriceAndSumAmount,
@@ -19,5 +20,6 @@ module.exports = {
   normalizeApiData,
   getAuthFromDb,
   getAllowedCollsNames,
-  getMethodArgMap
+  getMethodArgMap,
+  getSyncCollName
 }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -174,7 +174,7 @@ class DataInserter extends EventEmitter {
     await this.insertNewPublicDataToDb(progress)
 
     await this.wsEventEmitter
-      .emitSyncingStep(() => 'DB_PREPARATION')
+      .emitSyncingStep('DB_PREPARATION')
     await this._afterAllInserts()
 
     if (typeof this.dao.optimize === 'function') {
@@ -236,7 +236,7 @@ class DataInserter extends EventEmitter {
     }
 
     await this.wsEventEmitter
-      .emitSyncingStep(() => 'CHECKING_NEW_PUBLIC_DATA')
+      .emitSyncingStep('CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewPublicData()
     const size = methodCollMap.size
@@ -249,9 +249,8 @@ class DataInserter extends EventEmitter {
         return
       }
 
-      await this.wsEventEmitter.emitSyncingStep(
-        () => `SYNCING_${getSyncCollName(method)}`
-      )
+      await this.wsEventEmitter
+        .emitSyncingStep(`SYNCING_${getSyncCollName(method)}`)
 
       await this._updateApiDataArrObjTypeToDb(method, item)
       await this._updateApiDataArrTypeToDb(method, item)
@@ -281,11 +280,10 @@ class DataInserter extends EventEmitter {
       return userProgress
     }
 
-    await this.wsEventEmitter
-      .emitSyncingStepToOne(
-        () => 'CHECKING_NEW_PRIVATE_DATA',
-        auth
-      )
+    await this.wsEventEmitter.emitSyncingStepToOne(
+      'CHECKING_NEW_PRIVATE_DATA',
+      auth
+    )
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
@@ -299,7 +297,7 @@ class DataInserter extends EventEmitter {
       }
 
       await this.wsEventEmitter.emitSyncingStepToOne(
-        () => `SYNCING_${getSyncCollName(method)}`,
+        `SYNCING_${getSyncCollName(method)}`,
         auth
       )
 

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -27,7 +27,8 @@ const {
   normalizeApiData,
   getAuthFromDb,
   getAllowedCollsNames,
-  getMethodArgMap
+  getMethodArgMap,
+  getSyncCollName
 } = require('./helpers')
 const DataInserterHook = require('./hooks/data.inserter.hook')
 const {
@@ -58,7 +59,8 @@ class DataInserter extends EventEmitter {
     convertCurrencyHook,
     recalcSubAccountLedgersBalancesHook,
     dataChecker,
-    syncInterrupter
+    syncInterrupter,
+    wsEventEmitter
   ) {
     super()
 
@@ -74,6 +76,7 @@ class DataInserter extends EventEmitter {
     this.recalcSubAccountLedgersBalancesHook = recalcSubAccountLedgersBalancesHook
     this.dataChecker = dataChecker
     this.syncInterrupter = syncInterrupter
+    this.wsEventEmitter = wsEventEmitter
 
     this._asyncProgressHandlers = []
     this._auth = null
@@ -170,6 +173,8 @@ class DataInserter extends EventEmitter {
 
     await this.insertNewPublicDataToDb(progress)
 
+    await this.wsEventEmitter
+      .emitSyncingStep(() => 'DB_PREPARATION')
     await this._afterAllInserts()
 
     if (typeof this.dao.optimize === 'function') {
@@ -230,6 +235,8 @@ class DataInserter extends EventEmitter {
       return
     }
 
+    await this.wsEventEmitter
+      .emitSyncingStepToOne(() => 'CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewPublicData()
     const size = methodCollMap.size
@@ -241,6 +248,10 @@ class DataInserter extends EventEmitter {
       if (this._isInterrupted) {
         return
       }
+
+      await this.wsEventEmitter.emitSyncingStepToOne(
+        () => `SYNCING_${getSyncCollName(method)}`
+      )
 
       await this._updateApiDataArrObjTypeToDb(method, item)
       await this._updateApiDataArrTypeToDb(method, item)
@@ -270,6 +281,8 @@ class DataInserter extends EventEmitter {
       return userProgress
     }
 
+    await this.wsEventEmitter
+      .emitSyncingStepToOne(() => 'CHECKING_NEW_PRIVATE_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
@@ -281,6 +294,10 @@ class DataInserter extends EventEmitter {
       if (this._isInterrupted) {
         return userProgress
       }
+
+      await this.wsEventEmitter.emitSyncingStepToOne(
+        () => `SYNCING_${getSyncCollName(method)}`
+      )
 
       const { start } = schema
 
@@ -822,5 +839,6 @@ decorate(inject(TYPES.ConvertCurrencyHook), DataInserter, 8)
 decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 9)
 decorate(inject(TYPES.DataChecker), DataInserter, 10)
 decorate(inject(TYPES.SyncInterrupter), DataInserter, 11)
+decorate(inject(TYPES.WSEventEmitter), DataInserter, 12)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -60,7 +60,8 @@ class DataInserter extends EventEmitter {
     recalcSubAccountLedgersBalancesHook,
     dataChecker,
     syncInterrupter,
-    wsEventEmitter
+    wsEventEmitter,
+    syncCollsManager
   ) {
     super()
 
@@ -77,6 +78,7 @@ class DataInserter extends EventEmitter {
     this.dataChecker = dataChecker
     this.syncInterrupter = syncInterrupter
     this.wsEventEmitter = wsEventEmitter
+    this.syncCollsManager = syncCollsManager
 
     this._asyncProgressHandlers = []
     this._auth = null
@@ -333,14 +335,10 @@ class DataInserter extends EventEmitter {
         ) {
           const { _id } = { ...auth }
 
-          await this.dao.insertElemToDb(
-            this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
-            {
-              collName: method,
-              user_id: _id
-            },
-            { isReplacedIfExists: true }
-          )
+          await this.syncCollsManager.setCollAsSynced({
+            collName: method,
+            user_id: _id
+          })
         }
       }
 
@@ -842,5 +840,6 @@ decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 9)
 decorate(inject(TYPES.DataChecker), DataInserter, 10)
 decorate(inject(TYPES.SyncInterrupter), DataInserter, 11)
 decorate(inject(TYPES.WSEventEmitter), DataInserter, 12)
+decorate(inject(TYPES.SyncCollsManager), DataInserter, 12)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -236,7 +236,7 @@ class DataInserter extends EventEmitter {
     }
 
     await this.wsEventEmitter
-      .emitSyncingStepToOne(() => 'CHECKING_NEW_PUBLIC_DATA')
+      .emitSyncingStep(() => 'CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewPublicData()
     const size = methodCollMap.size
@@ -249,7 +249,7 @@ class DataInserter extends EventEmitter {
         return
       }
 
-      await this.wsEventEmitter.emitSyncingStepToOne(
+      await this.wsEventEmitter.emitSyncingStep(
         () => `SYNCING_${getSyncCollName(method)}`
       )
 
@@ -282,7 +282,10 @@ class DataInserter extends EventEmitter {
     }
 
     await this.wsEventEmitter
-      .emitSyncingStepToOne(() => 'CHECKING_NEW_PRIVATE_DATA')
+      .emitSyncingStepToOne(
+        () => 'CHECKING_NEW_PRIVATE_DATA',
+        auth
+      )
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
@@ -296,7 +299,8 @@ class DataInserter extends EventEmitter {
       }
 
       await this.wsEventEmitter.emitSyncingStepToOne(
-        () => `SYNCING_${getSyncCollName(method)}`
+        () => `SYNCING_${getSyncCollName(method)}`,
+        auth
       )
 
       const { start } = schema

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -293,7 +293,8 @@ class DataInserter extends EventEmitter {
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
-    const { _id: userId } = { ...auth }
+    const { _id: userId, subUser } = { ...auth }
+    const { _id: subUserId } = { ...subUser }
 
     let count = 0
     let progress = 0
@@ -333,7 +334,7 @@ class DataInserter extends EventEmitter {
       }
 
       await this.syncCollsManager.setCollAsSynced({
-        collName: method, userId
+        collName: method, userId, subUserId
       })
 
       count += 1
@@ -834,6 +835,6 @@ decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 9)
 decorate(inject(TYPES.DataChecker), DataInserter, 10)
 decorate(inject(TYPES.SyncInterrupter), DataInserter, 11)
 decorate(inject(TYPES.WSEventEmitter), DataInserter, 12)
-decorate(inject(TYPES.SyncCollsManager), DataInserter, 12)
+decorate(inject(TYPES.SyncCollsManager), DataInserter, 13)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -258,6 +258,10 @@ class DataInserter extends EventEmitter {
       await this._updateApiDataArrTypeToDb(method, item)
       await this._insertApiDataPublicArrObjTypeToDb(method, item)
 
+      await this.syncCollsManager.setCollAsSynced({
+        collName: method
+      })
+
       count += 1
       progress = Math.round(
         prevProgress + (count / size) * 100 * ((100 - prevProgress) / 100)
@@ -289,6 +293,7 @@ class DataInserter extends EventEmitter {
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
+    const { _id: userId } = { ...auth }
 
     let count = 0
     let progress = 0
@@ -306,10 +311,7 @@ class DataInserter extends EventEmitter {
       const { start } = schema
 
       for (const [symbol, dates] of start) {
-        const {
-          baseStartFrom = 0,
-          baseStartTo
-        } = { ...dates }
+        const { baseStartFrom = 0 } = { ...dates }
         const addApiParams = (
           !symbol ||
           symbol === ALL_SYMBOLS_TO_SYNC ||
@@ -328,19 +330,11 @@ class DataInserter extends EventEmitter {
           addApiParams,
           auth
         )
-
-        if (
-          Number.isInteger(baseStartFrom) &&
-          Number.isInteger(baseStartTo)
-        ) {
-          const { _id } = { ...auth }
-
-          await this.syncCollsManager.setCollAsSynced({
-            collName: method,
-            user_id: _id
-          })
-        }
       }
+
+      await this.syncCollsManager.setCollAsSynced({
+        collName: method, userId
+      })
 
       count += 1
       progress = Math.round(

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -8,7 +8,7 @@
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
 
-const SUPPORTED_DB_VERSION = 21
+const SUPPORTED_DB_VERSION = 22
 
 const TABLES_NAMES = require('./tables-names')
 const {
@@ -773,6 +773,7 @@ const _models = new Map([
     {
       _id: ID_PRIMARY_KEY,
       collName: 'VARCHAR(255)',
+      mts: 'BIGINT',
       user_id: 'INT NOT NULL',
 
       [UNIQUE_INDEX_FIELD_NAME]: ['collName', 'user_id'],

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -774,7 +774,7 @@ const _models = new Map([
       _id: ID_PRIMARY_KEY,
       collName: 'VARCHAR(255)',
       mts: 'BIGINT',
-      user_id: 'INT NOT NULL',
+      user_id: 'INT',
 
       [UNIQUE_INDEX_FIELD_NAME]: ['collName', 'user_id'],
       [CONSTR_FIELD_NAME]: `CONSTRAINT #{tableName}_fk_user_id

--- a/workers/loc.api/sync/schema/sync-schema.js
+++ b/workers/loc.api/sync/schema/sync-schema.js
@@ -22,6 +22,7 @@ const _methodCollMap = new Map([
       sort: [['mts', -1], ['id', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.LEDGERS)
     }
@@ -36,6 +37,7 @@ const _methodCollMap = new Map([
       sort: [['mtsCreate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.TRADES)
     }
@@ -50,6 +52,7 @@ const _methodCollMap = new Map([
       sort: [['mtsCreate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.FUNDING_TRADES)
     }
@@ -65,6 +68,7 @@ const _methodCollMap = new Map([
       hasNewData: false,
       start: [],
       confName: 'publicTradesConf',
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.PUBLIC_TRADES)
     }
@@ -88,6 +92,7 @@ const _methodCollMap = new Map([
       sort: [['timestamp', -1]],
       hasNewData: true,
       confName: 'statusMessagesConf',
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.STATUS_MESSAGES)
     }
@@ -102,6 +107,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.ORDERS)
     }
@@ -116,6 +122,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdated', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.MOVEMENTS)
     }
@@ -130,6 +137,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.FUNDING_OFFER_HISTORY)
     }
@@ -144,6 +152,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.FUNDING_LOAN_HISTORY)
     }
@@ -158,6 +167,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.FUNDING_CREDIT_HISTORY)
     }
@@ -172,6 +182,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.POSITIONS_HISTORY)
     }
@@ -186,6 +197,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.POSITIONS_SNAPSHOT)
     }
@@ -200,6 +212,7 @@ const _methodCollMap = new Map([
       sort: [['time', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.LOGINS)
     }
@@ -214,6 +227,7 @@ const _methodCollMap = new Map([
       sort: [['mtsCreate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CHANGE_LOGS)
     }
@@ -229,6 +243,7 @@ const _methodCollMap = new Map([
       hasNewData: false,
       start: [],
       confName: 'tickersHistoryConf',
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.TICKERS_HISTORY)
     }
@@ -244,6 +259,7 @@ const _methodCollMap = new Map([
       subQuery: {
         sort: [['mts', -1], ['id', -1]]
       },
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.HIDDEN_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.LEDGERS),
       dataStructureConverter: (accum, {
@@ -274,6 +290,7 @@ const _methodCollMap = new Map([
       field: 'pairs',
       sort: [['pairs', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
       model: getModelOf(TABLES_NAMES.SYMBOLS)
     }
@@ -286,6 +303,7 @@ const _methodCollMap = new Map([
       fields: ['key', 'value'],
       sort: [['key', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.MAP_SYMBOLS)
     }
@@ -298,6 +316,7 @@ const _methodCollMap = new Map([
       field: 'pairs',
       sort: [['pairs', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
       model: getModelOf(TABLES_NAMES.INACTIVE_CURRENCIES)
     }
@@ -310,6 +329,7 @@ const _methodCollMap = new Map([
       field: 'pairs',
       sort: [['pairs', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
       model: getModelOf(TABLES_NAMES.INACTIVE_SYMBOLS)
     }
@@ -322,6 +342,7 @@ const _methodCollMap = new Map([
       field: 'pairs',
       sort: [['pairs', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
       model: getModelOf(TABLES_NAMES.FUTURES)
     }
@@ -334,6 +355,7 @@ const _methodCollMap = new Map([
       fields: ['id'],
       sort: [['name', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CURRENCIES)
     }
@@ -350,6 +372,7 @@ const _methodCollMap = new Map([
       hasNewData: false,
       start: [],
       confName: 'candlesConf',
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CANDLES)
     }

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -62,7 +62,8 @@ class SubAccount {
             'apiSecret',
             'timezone',
             'username',
-            'password'
+            'password',
+            'isNotProtected'
           ],
           isDecryptedApiKeys: true,
           isReturnedPassword: true,
@@ -70,12 +71,17 @@ class SubAccount {
         }
       )
 
-    const _subAccountPassword = (
+    const isSubAccountPwdEntered = (
       subAccountPassword &&
       typeof subAccountPassword === 'string'
     )
+    const _subAccountPassword = isSubAccountPwdEntered
       ? subAccountPassword
       : masterUser.password
+    const isNotProtected = (
+      !isSubAccountPwdEntered &&
+      masterUser.isNotProtected
+    )
 
     if (
       isSubAccountApiKeys(masterUser) ||
@@ -89,7 +95,8 @@ class SubAccount {
     const subAccount = {
       ...masterUser,
       ...getSubAccountAuthFromAuth(masterUser),
-      password: _subAccountPassword
+      password: _subAccountPassword,
+      isNotProtected
     }
 
     return this.dao.executeQueriesInTrans(async () => {
@@ -187,7 +194,8 @@ class SubAccount {
             {
               auth: {
                 ...auth,
-                password: _subAccountPassword
+                password: _subAccountPassword,
+                isNotProtected
               }
             },
             {

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -27,12 +27,18 @@ class SyncCollsManager {
   async hasCollBeenSyncedAtLeastOnce (params) {
     const {
       userId,
+      subUserId,
       collName
     } = { ...params }
 
+    const subUserIdFilter = Number.isInteger(subUserId)
+      ? { subUserId }
+      : {}
+
     const completedColl = await this._getCompletedCollBy({
       user_id: userId,
-      collName
+      collName,
+      ...subUserIdFilter
     })
 
     return (
@@ -45,6 +51,7 @@ class SyncCollsManager {
   setCollAsSynced (params) {
     const {
       userId,
+      subUserId,
       collName
     } = { ...params }
 
@@ -53,6 +60,7 @@ class SyncCollsManager {
       {
         collName,
         mts: Date.now(),
+        subUserId,
         user_id: userId
       },
       { isReplacedIfExists: true }

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -82,7 +82,6 @@ class SyncCollsManager {
         $isNull: ['user_id']
       }
     })
-    console.log('[completedColls]:'.bgBlue, completedColls)
 
     if (
       !Array.isArray(completedColls) ||
@@ -101,7 +100,6 @@ class SyncCollsManager {
     }
 
     const checkingRes = []
-    const names = []
 
     for (const [method, schema] of this._methodCollMap) {
       const {
@@ -123,7 +121,6 @@ class SyncCollsManager {
         ))
 
         checkingRes.push(isDone)
-        names.push(method)
 
         continue
       }
@@ -142,7 +139,6 @@ class SyncCollsManager {
         ))
 
         checkingRes.push(isDone)
-        names.push(method)
 
         continue
       }
@@ -155,11 +151,8 @@ class SyncCollsManager {
       ))
 
       checkingRes.push(isDone)
-      names.push(method)
     }
 
-    console.log('[checkingRes]:'.bgGreen, checkingRes)
-    console.log('[names]:'.bgGreen, names)
     return checkingRes.every((res) => res)
   }
 

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -41,6 +41,23 @@ class SyncCollsManager {
       completedColl.collName === collName
     )
   }
+
+  setCollAsSynced (params) {
+    const {
+      userId,
+      collName
+    } = { ...params }
+
+    return this.dao.insertElemToDb(
+      this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
+      {
+        collName,
+        mts: Date.now(),
+        user_id: userId
+      },
+      { isReplacedIfExists: true }
+    )
+  }
 }
 
 decorate(injectable(), SyncCollsManager)

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -16,6 +16,31 @@ class SyncCollsManager {
     this.dao = dao
     this.TABLES_NAMES = TABLES_NAMES
   }
+
+  _getCompletedCollBy (params = {}) {
+    return this.dao.getElemInCollBy(
+      this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
+      params
+    )
+  }
+
+  async hasCollBeenSyncedAtLeastOnce (params) {
+    const {
+      userId,
+      collName
+    } = { ...params }
+
+    const completedColl = await this._getCompletedCollBy({
+      user_id: userId,
+      collName
+    })
+
+    return (
+      completedColl &&
+      typeof completedColl === 'object' &&
+      completedColl.collName === collName
+    )
+  }
 }
 
 decorate(injectable(), SyncCollsManager)

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const TYPES = require('../../di/types')
+
+class SyncCollsManager {
+  constructor (
+    dao,
+    TABLES_NAMES
+  ) {
+    this.dao = dao
+    this.TABLES_NAMES = TABLES_NAMES
+  }
+}
+
+decorate(injectable(), SyncCollsManager)
+decorate(inject(TYPES.DAO), SyncCollsManager, 0)
+decorate(inject(TYPES.TABLES_NAMES), SyncCollsManager, 1)
+
+module.exports = SyncCollsManager

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -1,6 +1,10 @@
 'use strict'
 
 const {
+  AuthError
+} = require('bfx-report/workers/loc.api/errors')
+
+const {
   decorate,
   injectable,
   inject
@@ -8,19 +12,35 @@ const {
 
 const TYPES = require('../../di/types')
 
+const {
+  isHidden,
+  isPublic
+} = require('../schema/utils')
+
 class SyncCollsManager {
   constructor (
     dao,
-    TABLES_NAMES
+    TABLES_NAMES,
+    syncSchema
   ) {
     this.dao = dao
     this.TABLES_NAMES = TABLES_NAMES
+    this.syncSchema = syncSchema
+
+    this._methodCollMap = this.syncSchema.getMethodCollMap()
   }
 
-  _getCompletedCollBy (params = {}) {
+  _getCompletedCollBy (filter = {}) {
     return this.dao.getElemInCollBy(
       this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
-      params
+      filter
+    )
+  }
+
+  _getCompletedCollsBy (filter = {}) {
+    return this.dao.getElemsInCollBy(
+      this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
+      { filter }
     )
   }
 
@@ -48,6 +68,101 @@ class SyncCollsManager {
     )
   }
 
+  async haveCollsBeenSyncedAtLeastOnce (args) {
+    const { auth } = { ...args }
+    const {
+      _id: userId,
+      subUsers,
+      isSubAccount
+    } = auth
+
+    const completedColls = await this._getCompletedCollsBy({
+      $or: {
+        $eq: { user_id: userId },
+        $isNull: ['user_id']
+      }
+    })
+    console.log('[completedColls]:'.bgBlue, completedColls)
+
+    if (
+      !Array.isArray(completedColls) ||
+      completedColls.length === 0
+    ) {
+      return false
+    }
+    if (
+      isSubAccount &&
+      (
+        !Array.isArray(subUsers) ||
+        subUsers.length === 0
+      )
+    ) {
+      throw new AuthError()
+    }
+
+    const checkingRes = []
+    const names = []
+
+    for (const [method, schema] of this._methodCollMap) {
+      const {
+        type,
+        isSyncRequiredAtLeastOnce
+      } = schema
+
+      if (
+        isHidden(type) ||
+        !isSyncRequiredAtLeastOnce
+      ) {
+        continue
+      }
+      if (isPublic(type)) {
+        const isDone = completedColls.some((completedColl) => (
+          completedColl &&
+          typeof completedColl === 'object' &&
+          completedColl.collName === method
+        ))
+
+        checkingRes.push(isDone)
+        names.push(method)
+
+        continue
+      }
+      if (isSubAccount) {
+        const isDone = subUsers.every((subUser) => (
+          subUser &&
+          typeof subUser === 'object' &&
+          Number.isInteger(subUser._id) &&
+          completedColls.some((completedColl) => (
+            completedColl &&
+            typeof completedColl === 'object' &&
+            completedColl.collName === method &&
+            completedColl.user_id === userId &&
+            completedColl.subUserId === subUser._id
+          ))
+        ))
+
+        checkingRes.push(isDone)
+        names.push(method)
+
+        continue
+      }
+
+      const isDone = completedColls.some((completedColl) => (
+        completedColl &&
+        typeof completedColl === 'object' &&
+        completedColl.collName === method &&
+        completedColl.user_id === userId
+      ))
+
+      checkingRes.push(isDone)
+      names.push(method)
+    }
+
+    console.log('[checkingRes]:'.bgGreen, checkingRes)
+    console.log('[names]:'.bgGreen, names)
+    return checkingRes.every((res) => res)
+  }
+
   setCollAsSynced (params) {
     const {
       userId,
@@ -71,5 +186,6 @@ class SyncCollsManager {
 decorate(injectable(), SyncCollsManager)
 decorate(inject(TYPES.DAO), SyncCollsManager, 0)
 decorate(inject(TYPES.TABLES_NAMES), SyncCollsManager, 1)
+decorate(inject(TYPES.SyncSchema), SyncCollsManager, 2)
 
 module.exports = SyncCollsManager

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -265,10 +265,7 @@ class WSTransport {
 
       try {
         if (
-          (
-            typeof handler !== 'function' &&
-            handler === null
-          ) ||
+          handler === null ||
           (
             isEmittedToActiveUsers &&
             !this._isActiveUser(user)

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -29,6 +29,32 @@ class WSEventEmitter {
     )
   }
 
+  emitSyncingStep (
+    handler = () => {}
+  ) {
+    return this.wsTransport.sendToActiveUsers(
+      handler,
+      'emitSyncingStep'
+    )
+  }
+
+  emitSyncingStepToOne (
+    handler = () => {},
+    auth = {}
+  ) {
+    return this.emitSyncingStep((user, ...args) => {
+      if (
+        !auth ||
+        typeof auth !== 'object' ||
+        user._id !== auth._id
+      ) {
+        return
+      }
+
+      return handler(user, ...args)
+    })
+  }
+
   async emitRedirectingRequestsStatusToApi (
     handler = () => {}
   ) {

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -42,7 +42,7 @@ class WSEventEmitter {
     handler = () => {},
     auth = {}
   ) {
-    return this.emitSyncingStep((user, ...args) => {
+    return this.emitSyncingStep(async (user, ...args) => {
       if (
         !auth ||
         typeof auth !== 'object' ||
@@ -51,7 +51,9 @@ class WSEventEmitter {
         return
       }
 
-      return handler(user, ...args)
+      return typeof handler === 'function'
+        ? await handler(user, ...args)
+        : handler
     })
   }
 


### PR DESCRIPTION
This PR fixes the login for an unprotected sub-account. The `getUsers` method returns `"isNotProtected": false` for the `sub-account` in a case when the user does not require to protect the sub-account by a password