### PR TITLE
Add helper to decorate injectable class

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "moment": "^2.24.0",
     "scrypt-js": "^3.0.0",
     "uuid": "^8.0.0",
-    "yargs": "^13.2.4"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chai": "^4.2.0",
     "nodemon": "^1.18.10",
     "supertest": "^4.0.2",
-    "standard": "^14.3.1"
+    "standard": "^16.0.3"
   },
   "contributors": [
     "Paolo Ardoino <paolo@bitfinex.com>",

--- a/test/3-api-filter-sync-mode-sqlite.spec.js
+++ b/test/3-api-filter-sync-mode-sqlite.spec.js
@@ -586,7 +586,8 @@ describe('API filter', () => {
               'amount',
               'fees',
               'destinationAddress',
-              'transactionId'
+              'transactionId',
+              'note'
             ])
             assert(Number.isInteger(item.id))
             assert.include([12345, 12346, 12347], item.id)

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -319,7 +319,7 @@ module.exports = new Map([
         null,
         null,
         '0x754687b3cbee7cdc4b29107e325455c682dfc320ca0c4233c313263a27282760',
-        null
+        'look at this note'
       ],
       [
         10012345,
@@ -343,7 +343,7 @@ module.exports = new Map([
         null,
         null,
         '0x754687b3cbee7cdc4b29107e325455c682dfc320ca0c4233c313263a27282760',
-        null
+        'look at this note'
       ],
       [
         20012345,
@@ -367,7 +367,7 @@ module.exports = new Map([
         null,
         null,
         '0x754687b3cbee7cdc4b29107e325455c682dfc320ca0c4233c313263a27282760',
-        null
+        'look at this note'
       ],
       [
         30012345,
@@ -391,7 +391,7 @@ module.exports = new Map([
         null,
         null,
         '0x754687b3cbee7cdc4b29107e325455c682dfc320ca0c4233c313263a27282760',
-        null
+        'look at this note'
       ],
       [
         40012345,
@@ -415,7 +415,7 @@ module.exports = new Map([
         null,
         null,
         '0x754687b3cbee7cdc4b29107e325455c682dfc320ca0c4233c313263a27282760',
-        null
+        'look at this note'
       ]
     ]
   ]

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -74,6 +74,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -93,10 +94,8 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
-    assert.isOk(
-      typeof res.body.result === 'string' ||
-      typeof res.body.result === 'number'
-    )
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
   })
 
   it('it should be successfully performed by the syncNow method', async function () {

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -2426,7 +2426,8 @@ module.exports = (
       'amount',
       'fees',
       'destinationAddress',
-      'transactionId'
+      'transactionId',
+      'note'
     ])
   })
 
@@ -2463,7 +2464,8 @@ module.exports = (
       'amount',
       'fees',
       'destinationAddress',
-      'transactionId'
+      'transactionId',
+      'note'
     ])
   })
 
@@ -2628,7 +2630,8 @@ module.exports = (
       'amount',
       'fees',
       'destinationAddress',
-      'transactionId'
+      'transactionId',
+      'note'
     ])
   })
 

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -334,6 +334,26 @@ module.exports = (
     })
   })
 
+  it('it should be successfully performed by the haveCollsBeenSyncedAtLeastOnce method, returns false', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'haveCollsBeenSyncedAtLeastOnce',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
+    assert.isNotOk(res.body.result)
+  })
+
   it('it should be successfully performed by the enableSyncMode method', async function () {
     this.timeout(5000)
 
@@ -420,6 +440,26 @@ module.exports = (
 
       await delay()
     }
+  })
+
+  it('it should be successfully performed by the haveCollsBeenSyncedAtLeastOnce method, returns true', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'haveCollsBeenSyncedAtLeastOnce',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
   })
 
   it('it should be successfully performed by the editPublicTradesConf method, where an object is passed', async function () {

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -350,6 +350,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -369,10 +370,8 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
-    assert.isOk(
-      typeof res.body.result === 'string' ||
-      typeof res.body.result === 'number'
-    )
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
   })
 
   it('it should be successfully performed by the isSchedulerEnabled method', async function () {
@@ -443,6 +442,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -502,6 +502,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -583,6 +584,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -642,6 +644,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -725,6 +728,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -805,6 +809,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 
@@ -914,6 +919,7 @@ module.exports = (
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
   })
 

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -29,8 +29,7 @@ const argv = require('yargs')
     type: 'string'
   })
   .option('secretKey', {
-    type: 'string',
-    default: 'secretKey'
+    type: 'string'
   })
   .option('schedulerRule', {
     type: 'string'

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -16,6 +16,9 @@ const TABLES_NAMES = require('../sync/schema/tables-names')
 const ALLOWED_COLLS = require('../sync/schema/allowed.colls')
 const SYNC_API_METHODS = require('../sync/schema/sync.api.methods')
 const SYNC_QUEUE_STATES = require('../sync/sync.queue/sync.queue.states')
+const CHECKER_NAMES = require(
+  '../sync/data.consistency.checker/checker.names'
+)
 const WSTransport = require('../ws-transport')
 const WSEventEmitter = require(
   '../ws-transport/ws.event.emitter'
@@ -27,6 +30,7 @@ const Sync = require('../sync')
 const SyncInterrupter = require('../sync/sync.interrupter')
 const SyncQueue = require('../sync/sync.queue')
 const SyncCollsManager = require('../sync/sync.colls.manager')
+const DataConsistencyChecker = require('../sync/data.consistency.checker')
 const {
   redirectRequestsToApi,
   FOREX_SYMBS
@@ -100,6 +104,7 @@ module.exports = ({
           ['_ALLOWED_COLLS', TYPES.ALLOWED_COLLS],
           ['_SYNC_API_METHODS', TYPES.SYNC_API_METHODS],
           ['_SYNC_QUEUE_STATES', TYPES.SYNC_QUEUE_STATES],
+          ['_CHECKER_NAMES', TYPES.CHECKER_NAMES],
           ['_prepareResponse', TYPES.PrepareResponse],
           ['_subAccount', TYPES.SubAccount],
           ['_progress', TYPES.Progress],
@@ -120,7 +125,8 @@ module.exports = ({
           ['_orderTrades', TYPES.OrderTrades],
           ['_authenticator', TYPES.Authenticator],
           ['_privResponder', TYPES.PrivResponder],
-          ['_syncCollsManager', TYPES.SyncCollsManager]
+          ['_syncCollsManager', TYPES.SyncCollsManager],
+          ['_dataConsistencyChecker', TYPES.DataConsistencyChecker]
         ]
       })
     rebind(TYPES.RServiceDepsSchemaAliase)
@@ -142,6 +148,7 @@ module.exports = ({
     bind(TYPES.ALLOWED_COLLS).toConstantValue(ALLOWED_COLLS)
     bind(TYPES.SYNC_API_METHODS).toConstantValue(SYNC_API_METHODS)
     bind(TYPES.SYNC_QUEUE_STATES).toConstantValue(SYNC_QUEUE_STATES)
+    bind(TYPES.CHECKER_NAMES).toConstantValue(CHECKER_NAMES)
     bind(TYPES.GRC_BFX_OPTS).toConstantValue(grcBfxOpts)
     bind(TYPES.FOREX_SYMBS).toConstantValue(FOREX_SYMBS)
     bind(TYPES.WSTransport)
@@ -246,6 +253,9 @@ module.exports = ({
       .inSingletonScope()
     bind(TYPES.SyncCollsManager)
       .to(SyncCollsManager)
+      .inSingletonScope()
+    bind(TYPES.DataConsistencyChecker)
+      .to(DataConsistencyChecker)
       .inSingletonScope()
     bind(TYPES.Sync)
       .to(Sync)

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -30,7 +30,12 @@ const Sync = require('../sync')
 const SyncInterrupter = require('../sync/sync.interrupter')
 const SyncQueue = require('../sync/sync.queue')
 const SyncCollsManager = require('../sync/sync.colls.manager')
-const DataConsistencyChecker = require('../sync/data.consistency.checker')
+const Checkers = require(
+  '../sync/data.consistency.checker/checkers'
+)
+const DataConsistencyChecker = require(
+  '../sync/data.consistency.checker'
+)
 const {
   redirectRequestsToApi,
   FOREX_SYMBS
@@ -253,6 +258,9 @@ module.exports = ({
       .inSingletonScope()
     bind(TYPES.SyncCollsManager)
       .to(SyncCollsManager)
+      .inSingletonScope()
+    bind(TYPES.Checkers)
+      .to(Checkers)
       .inSingletonScope()
     bind(TYPES.DataConsistencyChecker)
       .to(DataConsistencyChecker)

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -26,6 +26,7 @@ const syncSchema = require('../sync/schema')
 const Sync = require('../sync')
 const SyncInterrupter = require('../sync/sync.interrupter')
 const SyncQueue = require('../sync/sync.queue')
+const SyncCollsManager = require('../sync/sync.colls.manager')
 const {
   redirectRequestsToApi,
   FOREX_SYMBS
@@ -241,6 +242,9 @@ module.exports = ({
       .to(RecalcSubAccountLedgersBalancesHook)
     bind(TYPES.SyncQueue)
       .to(SyncQueue)
+      .inSingletonScope()
+    bind(TYPES.SyncCollsManager)
+      .to(SyncCollsManager)
       .inSingletonScope()
     bind(TYPES.Sync)
       .to(Sync)

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -119,7 +119,8 @@ module.exports = ({
           ['_positionsAudit', TYPES.PositionsAudit],
           ['_orderTrades', TYPES.OrderTrades],
           ['_authenticator', TYPES.Authenticator],
-          ['_privResponder', TYPES.PrivResponder]
+          ['_privResponder', TYPES.PrivResponder],
+          ['_syncCollsManager', TYPES.SyncCollsManager]
         ]
       })
     rebind(TYPES.RServiceDepsSchemaAliase)

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -54,5 +54,6 @@ module.exports = {
   Crypto: Symbol.for('Crypto'),
   Authenticator: Symbol.for('Authenticator'),
   PrivResponder: Symbol.for('PrivResponder'),
-  SyncInterrupter: Symbol.for('SyncInterrupter')
+  SyncInterrupter: Symbol.for('SyncInterrupter'),
+  SyncCollsManager: Symbol.for('SyncCollsManager')
 }

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -8,6 +8,7 @@ module.exports = {
   ALLOWED_COLLS: Symbol.for('ALLOWED_COLLS'),
   SYNC_API_METHODS: Symbol.for('SYNC_API_METHODS'),
   SYNC_QUEUE_STATES: Symbol.for('SYNC_QUEUE_STATES'),
+  CHECKER_NAMES: Symbol.for('CHECKER_NAMES'),
   FrameworkRServiceDepsSchema: Symbol.for('FrameworkRServiceDepsSchema'),
   GRC_BFX_OPTS: Symbol.for('GRC_BFX_OPTS'),
   ApiMiddlewareHandlerAfter: Symbol.for('ApiMiddlewareHandlerAfter'),
@@ -55,5 +56,6 @@ module.exports = {
   Authenticator: Symbol.for('Authenticator'),
   PrivResponder: Symbol.for('PrivResponder'),
   SyncInterrupter: Symbol.for('SyncInterrupter'),
-  SyncCollsManager: Symbol.for('SyncCollsManager')
+  SyncCollsManager: Symbol.for('SyncCollsManager'),
+  DataConsistencyChecker: Symbol.for('DataConsistencyChecker')
 }

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -57,5 +57,6 @@ module.exports = {
   PrivResponder: Symbol.for('PrivResponder'),
   SyncInterrupter: Symbol.for('SyncInterrupter'),
   SyncCollsManager: Symbol.for('SyncCollsManager'),
+  Checkers: Symbol.for('Checkers'),
   DataConsistencyChecker: Symbol.for('DataConsistencyChecker')
 }

--- a/workers/loc.api/di/utils/decorate-injectable.js
+++ b/workers/loc.api/di/utils/decorate-injectable.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const {
+  decorateInjectable
+} = require('bfx-report/workers/loc.api/di/utils')
+
+const _TYPES = require('../types')
+
+module.exports = (
+  ModuleClass,
+  getDepsTypesFn,
+  TYPES = _TYPES
+) => decorateInjectable(
+  ModuleClass,
+  getDepsTypesFn,
+  TYPES
+)

--- a/workers/loc.api/di/utils/index.js
+++ b/workers/loc.api/di/utils/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const decorateInjectable = require('./decorate-injectable')
+
+module.exports = {
+  decorateInjectable
+}

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -153,6 +153,12 @@ class SyncedPositionsSnapshotParamsError extends BaseError {
   }
 }
 
+class DataConsistencyCheckerFindingError extends BaseError {
+  constructor (message = 'ERR_DATA_CONSISTENCY_CHECKER_HAS_NOT_BEEN_FOUND') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -178,5 +184,6 @@ module.exports = {
   SubAccountLedgersBalancesRecalcError,
   DatePropNameError,
   GetPublicDataError,
-  SyncedPositionsSnapshotParamsError
+  SyncedPositionsSnapshotParamsError,
+  DataConsistencyCheckerFindingError
 }

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -159,6 +159,12 @@ class DataConsistencyCheckerFindingError extends BaseError {
   }
 }
 
+class DataConsistencyError extends BaseError {
+  constructor (message = 'ERR_COLLECTIONS_DATA_IS_NOT_CONSISTENT') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -185,5 +191,6 @@ module.exports = {
   DatePropNameError,
   GetPublicDataError,
   SyncedPositionsSnapshotParamsError,
-  DataConsistencyCheckerFindingError
+  DataConsistencyCheckerFindingError,
+  DataConsistencyError
 }

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -1,9 +1,5 @@
 'use strict'
 
-const {
-  decorate,
-  inject
-} = require('inversify')
 const BaseCsvJobData = require(
   'bfx-report/workers/loc.api/generate-csv/csv.job.data'
 )
@@ -12,13 +8,18 @@ const {
   checkJobAndGetUserData
 } = require('bfx-report/workers/loc.api/helpers')
 
-const TYPES = require('../di/types')
-
 const {
   checkParams,
   getDateString
 } = require('../helpers')
 
+const { decorateInjectable } = require('../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.FullSnapshotReportCsvWriter,
+  TYPES.FullTaxReportCsvWriter
+]
 class CsvJobData extends BaseCsvJobData {
   constructor (
     rService,
@@ -574,8 +575,6 @@ class CsvJobData extends BaseCsvJobData {
   }
 }
 
-decorate(inject(TYPES.RService), CsvJobData, 0)
-decorate(inject(TYPES.FullSnapshotReportCsvWriter), CsvJobData, 1)
-decorate(inject(TYPES.FullTaxReportCsvWriter), CsvJobData, 2)
+decorateInjectable(CsvJobData, depsTypes)
 
 module.exports = CsvJobData

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -424,7 +424,8 @@ class CsvJobData extends BaseCsvJobData {
           amount: 'AMOUNT',
           fees: 'FEES',
           destinationAddress: 'DESCRIPTION',
-          transactionId: 'TRANSACTION ID'
+          transactionId: 'TRANSACTION ID',
+          note: 'NOTE'
         },
         periodBalances: {
           walletsTotalBalanceUsd: 'WALLETS TOTAL BALANCE USD',

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -5,7 +5,8 @@ const {
   checkParamsAuth,
   tryParseJSON,
   collObjToArr,
-  getDateString
+  getDateString,
+  isNotSyncRequired
 } = require('./utils')
 const {
   isEnotfoundError,
@@ -23,6 +24,7 @@ module.exports = {
   tryParseJSON,
   collObjToArr,
   getDateString,
+  isNotSyncRequired,
   isEnotfoundError,
   isEaiAgainError,
   isSubAccountApiKeys,

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -62,9 +62,20 @@ const getDateString = (mc) => {
   return new Date(mc).toDateString().split(' ').join('-')
 }
 
+const isNotSyncRequired = (args) => {
+  return (
+    args &&
+    typeof args === 'object' &&
+    args.params &&
+    typeof args.params === 'object' &&
+    args.params.isNotSyncRequired
+  )
+}
+
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
   collObjToArr,
-  getDateString
+  getDateString,
+  isNotSyncRequired
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1147,9 +1147,8 @@ class FrameworkReportService extends ReportService {
    */
   getWallets (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.WALLETS, args)
 
       checkParams(args, 'paramsSchemaForWallets')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1213,9 +1213,8 @@ class FrameworkReportService extends ReportService {
 
   getTradedVolume (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.TRADED_VOLUME, args)
 
       checkParams(args, 'paramsSchemaForTradedVolumeApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -21,6 +21,7 @@ const {
 const {
   checkParams,
   checkParamsAuth,
+  isNotSyncRequired,
   isEnotfoundError,
   isEaiAgainError,
   collObjToArr,
@@ -220,6 +221,11 @@ class FrameworkReportService extends ReportService {
         this._TABLES_NAMES.SYNC_MODE,
         { isEnable: true }
       )
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
       await this._sync.start(true)
 
       return true
@@ -281,8 +287,13 @@ class FrameworkReportService extends ReportService {
         { isEnable: true }
       )
 
-      return this._sync
-        .start(true, this._ALLOWED_COLLS.ALL)
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync.start(true)
+
+      return true
     }, 'enableScheduler', args, cb)
   }
 
@@ -378,7 +389,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('publicTradesConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.PUBLIC_TRADES)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.PUBLIC_TRADES)
 
       return true
     }, 'editPublicTradesConf', args, cb)
@@ -390,7 +407,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('tickersHistoryConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.TICKERS_HISTORY)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.TICKERS_HISTORY)
 
       return true
     }, 'editTickersHistoryConf', args, cb)
@@ -402,7 +425,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('statusMessagesConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.STATUS_MESSAGES)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.STATUS_MESSAGES)
 
       return true
     }, 'editStatusMessagesConf', args, cb)
@@ -414,7 +443,13 @@ class FrameworkReportService extends ReportService {
 
       await this._publicСollsСonfAccessors
         .editPublicСollsСonf('candlesConf', args)
-      await this._sync.start(true, this._ALLOWED_COLLS.CANDLES)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
+      await this._sync
+        .start(true, this._ALLOWED_COLLS.CANDLES)
 
       return true
     }, 'editCandlesConf', args, cb)
@@ -426,6 +461,11 @@ class FrameworkReportService extends ReportService {
 
       const syncedColls = await this._publicСollsСonfAccessors
         .editAllPublicСollsСonfs(args)
+
+      if (isNotSyncRequired(args)) {
+        return true
+      }
+
       await this._sync.start(true, syncedColls)
 
       return true

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1224,9 +1224,8 @@ class FrameworkReportService extends ReportService {
 
   getFeesReport (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.FEES_REPORT, args)
 
       checkParams(args, 'paramsSchemaForFeesReportApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -338,6 +338,13 @@ class FrameworkReportService extends ReportService {
     }, 'getSyncProgress', args, cb)
   }
 
+  haveCollsBeenSyncedAtLeastOnce (space, args, cb) {
+    return this._privResponder(() => {
+      return this._syncCollsManager
+        .haveCollsBeenSyncedAtLeastOnce(args)
+    }, 'haveCollsBeenSyncedAtLeastOnce', args, cb)
+  }
+
   syncNow (space, args = {}, cb) {
     return this._privResponder(() => {
       const { params } = { ...args }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1180,9 +1180,8 @@ class FrameworkReportService extends ReportService {
 
   getPositionsSnapshot (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.POSITIONS_SNAPSHOT, args)
 
       checkParams(args, 'paramsSchemaForPositionsSnapshotApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1202,9 +1202,8 @@ class FrameworkReportService extends ReportService {
 
   getFullTaxReport (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.FULL_TAX_REPORT, args)
 
       checkParams(args, 'paramsSchemaForFullTaxReportApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1158,9 +1158,8 @@ class FrameworkReportService extends ReportService {
 
   getBalanceHistory (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.BALANCE_HISTORY, args)
 
       checkParams(args, 'paramsSchemaForBalanceHistoryApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1191,9 +1191,8 @@ class FrameworkReportService extends ReportService {
 
   getFullSnapshotReport (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.FULL_SNAPSHOT_REPORT, args)
 
       checkParams(args, 'paramsSchemaForFullSnapshotReportApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -496,6 +496,12 @@ class FrameworkReportService extends ReportService {
         return collObjToArr(res, field)
       })
 
+      const res = await Promise.all(promises)
+
+      if (res.some(isEmpty)) {
+        return super.getSymbols(space, args)
+      }
+
       const [
         symbols,
         futures,
@@ -503,16 +509,7 @@ class FrameworkReportService extends ReportService {
         mapSymbols,
         inactiveCurrencies,
         inactiveSymbols
-      ] = await Promise.all(promises)
-
-      if (
-        isEmpty(symbols) &&
-        isEmpty(futures) &&
-        isEmpty(currencies) &&
-        isEmpty(inactiveSymbols)
-      ) {
-        return super.getSymbols(space, args)
-      }
+      ] = res
 
       const pairs = [...symbols, ...futures]
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1169,9 +1169,8 @@ class FrameworkReportService extends ReportService {
 
   getWinLoss (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.WIN_LOSS, args)
 
       checkParams(args, 'paramsSchemaForWinLossApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -15,8 +15,7 @@ const {
 
 const ReportService = require('./service.report')
 const {
-  ServerAvailabilityError,
-  DuringSyncMethodAccessError
+  ServerAvailabilityError
 } = require('./errors')
 const {
   checkParams,
@@ -1235,9 +1234,8 @@ class FrameworkReportService extends ReportService {
 
   getPerformingLoan (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.PERFORMING_LOAN, args)
 
       checkParams(args, 'paramsSchemaForPerformingLoanApi')
 

--- a/workers/loc.api/sync/authenticator/helpers/pick-session-props.js
+++ b/workers/loc.api/sync/authenticator/helpers/pick-session-props.js
@@ -4,7 +4,7 @@ const pickProps = require('./pick-props')
 
 module.exports = (session, isReturnedPassword) => {
   const passwordProp = isReturnedPassword
-    ? ['password']
+    ? ['password', 'isNotProtected']
     : []
   const allowedProps = [
     '_id',

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -2,15 +2,9 @@
 
 const { v4: uuidv4 } = require('uuid')
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   AuthError
 } = require('bfx-report/workers/loc.api/errors')
 
-const TYPES = require('../../di/types')
 const { serializeVal } = require('../dao/helpers')
 const { isSubAccountApiKeys } = require('../../helpers')
 const {
@@ -23,6 +17,15 @@ const {
   pickSessionProps
 } = require('./helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.RService,
+  TYPES.Crypto,
+  TYPES.SyncFactory
+]
 class Authenticator {
   constructor (
     dao,
@@ -869,11 +872,6 @@ class Authenticator {
   }
 }
 
-decorate(injectable(), Authenticator)
-decorate(inject(TYPES.DAO), Authenticator, 0)
-decorate(inject(TYPES.TABLES_NAMES), Authenticator, 1)
-decorate(inject(TYPES.RService), Authenticator, 2)
-decorate(inject(TYPES.Crypto), Authenticator, 3)
-decorate(inject(TYPES.SyncFactory), Authenticator, 4)
+decorateInjectable(Authenticator, depsTypes)
 
 module.exports = Authenticator

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -160,10 +160,10 @@ class Authenticator {
     const userParam = isReturnedFullUserData
       ? fullUserData
       : {
-        email,
-        isSubAccount: user.isSubAccount,
-        token
-      }
+          email,
+          isSubAccount: user.isSubAccount,
+          token
+        }
 
     if (!isNotSetSession) {
       /**

--- a/workers/loc.api/sync/balance.history/index.js
+++ b/workers/loc.api/sync/balance.history/index.js
@@ -2,13 +2,7 @@
 
 const { isEmpty } = require('lodash')
 const moment = require('moment')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const {
   calcGroupedData,
   getMtsGroupedByTimeframe,
@@ -17,6 +11,16 @@ const {
 } = require('../helpers')
 const { getTimeframeQuery } = require('../dao/helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.Wallets,
+  TYPES.FOREX_SYMBS,
+  TYPES.CurrencyConverter,
+  TYPES.SYNC_API_METHODS,
+  TYPES.ALLOWED_COLLS
+]
 class BalanceHistory {
   constructor (
     dao,
@@ -454,12 +458,6 @@ class BalanceHistory {
   }
 }
 
-decorate(injectable(), BalanceHistory)
-decorate(inject(TYPES.DAO), BalanceHistory, 0)
-decorate(inject(TYPES.Wallets), BalanceHistory, 1)
-decorate(inject(TYPES.FOREX_SYMBS), BalanceHistory, 2)
-decorate(inject(TYPES.CurrencyConverter), BalanceHistory, 3)
-decorate(inject(TYPES.SYNC_API_METHODS), BalanceHistory, 4)
-decorate(inject(TYPES.ALLOWED_COLLS), BalanceHistory, 5)
+decorateInjectable(BalanceHistory, depsTypes)
 
 module.exports = BalanceHistory

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -7,22 +7,23 @@ const {
   orderBy
 } = require('lodash')
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   prepareResponse
 } = require('bfx-report/workers/loc.api/helpers')
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
 
-const TYPES = require('../../di/types')
 const {
   GetPublicDataError
 } = require('../../errors')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.Authenticator
+]
 class PublicСollsСonfAccessors {
   constructor (
     dao,
@@ -488,9 +489,6 @@ class PublicСollsСonfAccessors {
   }
 }
 
-decorate(injectable(), PublicСollsСonfAccessors)
-decorate(inject(TYPES.DAO), PublicСollsСonfAccessors, 0)
-decorate(inject(TYPES.TABLES_NAMES), PublicСollsСonfAccessors, 1)
-decorate(inject(TYPES.Authenticator), PublicСollsСonfAccessors, 2)
+decorateInjectable(PublicСollsСonfAccessors, depsTypes)
 
 module.exports = PublicСollsСonfAccessors

--- a/workers/loc.api/sync/crypto/index.js
+++ b/workers/loc.api/sync/crypto/index.js
@@ -3,15 +3,8 @@
 const crypto = require('crypto')
 const { promisify } = require('util')
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   AuthError
 } = require('bfx-report/workers/loc.api/errors')
-
-const TYPES = require('../../di/types')
 
 /**
  * Scrypt was introduced into Node.js in v10.5.0,
@@ -40,6 +33,11 @@ const scrypt = hasScrypt ? promisify(crypto.scrypt) : crypto.scrypt
 const randomBytes = promisify(crypto.randomBytes)
 const pbkdf2 = promisify(crypto.pbkdf2)
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.CONF
+]
 class Crypto {
   constructor (CONF) {
     this.CONF = CONF
@@ -158,7 +156,6 @@ class Crypto {
   }
 }
 
-decorate(injectable(), Crypto)
-decorate(inject(TYPES.CONF), Crypto, 0)
+decorateInjectable(Crypto, depsTypes)
 
 module.exports = Crypto

--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -3,11 +3,6 @@
 const moment = require('moment')
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
 const {
@@ -22,8 +17,17 @@ const {
   isForexSymb
 } = require('../helpers')
 const { tryParseJSON } = require('../../helpers')
-const TYPES = require('../../di/types')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.FOREX_SYMBS,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SYNC_API_METHODS
+]
 class CurrencyConverter {
   constructor (
     rService,
@@ -914,12 +918,6 @@ class CurrencyConverter {
   }
 }
 
-decorate(injectable(), CurrencyConverter)
-decorate(inject(TYPES.RService), CurrencyConverter, 0)
-decorate(inject(TYPES.DAO), CurrencyConverter, 1)
-decorate(inject(TYPES.SyncSchema), CurrencyConverter, 2)
-decorate(inject(TYPES.FOREX_SYMBS), CurrencyConverter, 3)
-decorate(inject(TYPES.ALLOWED_COLLS), CurrencyConverter, 4)
-decorate(inject(TYPES.SYNC_API_METHODS), CurrencyConverter, 5)
+decorateInjectable(CurrencyConverter, depsTypes)
 
 module.exports = CurrencyConverter

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -2,11 +2,6 @@
 
 const { promisify } = require('util')
 const setImmediatePromise = promisify(setImmediate)
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 const MAIN_DB_WORKER_ACTIONS = require(
   'bfx-facs-db-better-sqlite/worker/db-worker-actions/db-worker-actions.const'
 )
@@ -17,8 +12,6 @@ const {
 const {
   AuthError
 } = require('bfx-report/workers/loc.api/errors')
-
-const TYPES = require('../../di/types')
 
 const DAO = require('./dao')
 const {
@@ -64,6 +57,15 @@ const {
   convertData,
   prepareDbResponse
 } = require('./helpers/find-in-coll-by')
+
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DB,
+  TYPES.TABLES_NAMES,
+  TYPES.SyncSchema,
+  TYPES.DbMigratorFactory
+]
 class BetterSqliteDAO extends DAO {
   constructor (...args) {
     super(...args)
@@ -926,10 +928,6 @@ class BetterSqliteDAO extends DAO {
   }
 }
 
-decorate(injectable(), BetterSqliteDAO)
-decorate(inject(TYPES.DB), BetterSqliteDAO, 0)
-decorate(inject(TYPES.TABLES_NAMES), BetterSqliteDAO, 1)
-decorate(inject(TYPES.SyncSchema), BetterSqliteDAO, 2)
-decorate(inject(TYPES.DbMigratorFactory), BetterSqliteDAO, 3)
+decorateInjectable(BetterSqliteDAO, depsTypes)
 
 module.exports = BetterSqliteDAO

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -213,6 +213,13 @@ class BetterSqliteDAO extends DAO {
     })
   }
 
+  _vacuum () {
+    return this.query({
+      action: MAIN_DB_WORKER_ACTIONS.RUN,
+      sql: 'VACUUM'
+    })
+  }
+
   optimize () {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
@@ -266,6 +273,7 @@ class BetterSqliteDAO extends DAO {
     await this._createTablesIfNotExists()
     await this._createIndexisIfNotExists()
     await this._createTriggerIfNotExists()
+    await this._vacuum()
     await this.setCurrDbVer(this.syncSchema.SUPPORTED_DB_VERSION)
   }
 

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -1,14 +1,11 @@
 'use strict'
 
 const {
-  decorate,
-  injectable
-} = require('inversify')
-
-const {
   DAOInitializationError,
   ImplementationError
 } = require('../../errors')
+
+const { decorateInjectable } = require('../../di/utils')
 
 class DAO {
   constructor (
@@ -141,6 +138,6 @@ class DAO {
   async removeElemsFromDbIfNotInLists () { throw new ImplementationError() }
 }
 
-decorate(injectable(), DAO)
+decorateInjectable(DAO)
 
 module.exports = DAO

--- a/workers/loc.api/sync/dao/db-migrations/db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/db.migrator.js
@@ -1,17 +1,14 @@
 'use strict'
 
 const {
-  decorate,
-  injectable
-} = require('inversify')
-
-const {
   DbMigrationVerCorrectnessError,
   DbVersionTypeError,
   MigrationLaunchingError
 } = require('../../../errors')
 
 const Migration = require('./migration')
+
+const { decorateInjectable } = require('../../../di/utils')
 
 class DbMigrator {
   constructor (
@@ -132,6 +129,6 @@ class DbMigrator {
   }
 }
 
-decorate(injectable(), DbMigrator)
+decorateInjectable(DbMigrator)
 
 module.exports = DbMigrator

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v22.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v22.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+const { getSqlArrToModifyColumns } = require('./helpers')
+
+class MigrationV22 extends AbstractMigration {
+  /**
+   * @override
+   */
+  before () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'DROP INDEX IF EXISTS completedOnFirstSyncColls_collName_user_id',
+
+      'ALTER TABLE completedOnFirstSyncColls ADD COLUMN mts BIGINT',
+      'ALTER TABLE completedOnFirstSyncColls ADD COLUMN subUserId INT',
+
+      ...getSqlArrToModifyColumns(
+        'completedOnFirstSyncColls',
+        {
+          _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+          collName: 'VARCHAR(255) NOT NULL',
+          mts: 'BIGINT',
+          subUserId: 'INT',
+          user_id: 'INT',
+          __constraints__: [
+            `CONSTRAINT completedOnFirstSyncColls_fk_user_id
+              FOREIGN KEY (user_id)
+              REFERENCES users(_id)
+              ON UPDATE CASCADE
+              ON DELETE CASCADE`,
+            `CONSTRAINT completedOnFirstSyncColls_fk_subUserId
+              FOREIGN KEY (subUserId)
+              REFERENCES users(_id)
+              ON UPDATE CASCADE
+              ON DELETE CASCADE`
+          ]
+        }
+      ),
+
+      `CREATE UNIQUE INDEX completedOnFirstSyncColls_collName
+        ON completedOnFirstSyncColls (collName)
+        WHERE user_id IS NULL`,
+      `CREATE UNIQUE INDEX completedOnFirstSyncColls_user_id_collName
+        ON completedOnFirstSyncColls (user_id, collName)
+        WHERE user_id IS NOT NULL AND subUserId IS NULL`,
+      `CREATE UNIQUE INDEX completedOnFirstSyncColls_user_id_subUserId_collName
+        ON completedOnFirstSyncColls (user_id, subUserId, collName)
+        WHERE user_id IS NOT NULL AND subUserId IS NOT NULL`
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      'DROP INDEX IF EXISTS completedOnFirstSyncColls_collName',
+      'DROP INDEX IF EXISTS completedOnFirstSyncColls_user_id_collName',
+      'DROP INDEX IF EXISTS completedOnFirstSyncColls_user_id_subUserId_collName',
+
+      ...getSqlArrToModifyColumns(
+        'completedOnFirstSyncColls',
+        {
+          _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+          collName: 'VARCHAR(255)',
+          user_id: 'INT NOT NULL',
+          __constraints__: `CONSTRAINT completedOnFirstSyncColls_fk_user_id
+            FOREIGN KEY(user_id)
+            REFERENCES users(_id)
+            ON UPDATE CASCADE
+            ON DELETE CASCADE`
+        }
+      ),
+
+      `CREATE UNIQUE INDEX completedOnFirstSyncColls_collName_user_id
+        ON completedOnFirstSyncColls (collName, user_id)`
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  after () { return this.dao.enableForeignKeys() }
+}
+
+module.exports = MigrationV22

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v22.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v22.js
@@ -74,6 +74,17 @@ class MigrationV22 extends AbstractMigration {
           SELECT '_getChangeLogs' AS collName, subUserId, user_id FROM changeLogs
         ) WHERE subUserId IS NOT NULL`,
 
+      // Add public collections entries
+      `INSERT OR REPLACE INTO completedOnFirstSyncColls
+        (collName)
+        SELECT '_getSymbols' AS collName FROM symbols UNION
+        SELECT '_getMapSymbols' AS collName FROM mapSymbols UNION
+        SELECT '_getInactiveCurrencies' AS collName FROM inactiveCurrencies UNION
+        SELECT '_getInactiveSymbols' AS collName FROM inactiveSymbols UNION
+        SELECT '_getFutures' AS collName FROM futures UNION
+        SELECT '_getCurrencies' AS collName FROM currencies UNION
+        SELECT '_getCandles' AS collName FROM candles`,
+
       // Update private collections
       // Get mts from ledgers or logins to have
       // an approximate last sync start-up time

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v23.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v23.js
@@ -9,7 +9,10 @@ class MigrationV11 extends AbstractMigration {
    */
   up () {
     const sqlArr = [
-      'ALTER TABLE movements ADD COLUMN note TEXT'
+      'ALTER TABLE movements ADD COLUMN note TEXT',
+      'DELETE FROM movements',
+      `DELETE FROM completedOnFirstSyncColls
+        WHERE collName = '_getMovements'`
     ]
 
     this.addSql(sqlArr)

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v23.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v23.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+const { getSqlArrToModifyColumns } = require('./helpers')
+
+class MigrationV11 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'ALTER TABLE movements ADD COLUMN note TEXT'
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  beforeDown () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      ...getSqlArrToModifyColumns(
+        'movements',
+        {
+          _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+          id: 'BIGINT',
+          currency: 'VARCHAR(255)',
+          currencyName: 'VARCHAR(255)',
+          mtsStarted: 'BIGINT',
+          mtsUpdated: 'BIGINT',
+          status: 'VARCHAR(255)',
+          amount: 'DECIMAL(22,12)',
+          amountUsd: 'DECIMAL(22,12)',
+          fees: 'DECIMAL(22,12)',
+          destinationAddress: 'VARCHAR(255)',
+          transactionId: 'VARCHAR(255)',
+          note: 'TEXT',
+          subUserId: 'INT',
+          user_id: 'INT NOT NULL',
+          __constraints__: [
+            `CONSTRAINT movements_fk_user_id
+              FOREIGN KEY (user_id)
+              REFERENCES users(_id)
+              ON UPDATE CASCADE
+              ON DELETE CASCADE`,
+            `CONSTRAINT movements_fk_subUserId
+              FOREIGN KEY (subUserId)
+              REFERENCES users(_id)
+              ON UPDATE CASCADE
+              ON DELETE CASCADE`
+          ]
+        }
+      )
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  afterDown () { return this.dao.enableForeignKeys() }
+}
+
+module.exports = MigrationV11

--- a/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
@@ -1,18 +1,18 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../../di/types')
-
 const DbMigrator = require('./db.migrator')
 const {
   MigrationLaunchingError
 } = require('../../../errors')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.MigrationsFactory,
+  TYPES.TABLES_NAMES,
+  TYPES.SyncSchema,
+  TYPES.Logger
+]
 class SqliteDbMigrator extends DbMigrator {
   /**
    * @override
@@ -48,10 +48,6 @@ class SqliteDbMigrator extends DbMigrator {
   }
 }
 
-decorate(injectable(), SqliteDbMigrator)
-decorate(inject(TYPES.MigrationsFactory), SqliteDbMigrator, 0)
-decorate(inject(TYPES.TABLES_NAMES), SqliteDbMigrator, 1)
-decorate(inject(TYPES.SyncSchema), SqliteDbMigrator, 2)
-decorate(inject(TYPES.Logger), SqliteDbMigrator, 3)
+decorateInjectable(SqliteDbMigrator, depsTypes)
 
 module.exports = SqliteDbMigrator

--- a/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-filter-params.js
+++ b/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-filter-params.js
@@ -10,6 +10,7 @@ const getInsertableArrayObjectsFilter = require(
 const getStatusMessagesFilter = require(
   '../get-status-messages-filter'
 )
+const TABLES_NAMES = require('../../../schema/tables-names')
 
 module.exports = (args, methodColl, opts) => {
   const { auth, params } = { ...args }
@@ -31,10 +32,16 @@ module.exports = (args, methodColl, opts) => {
   }
 
   if (!isPublic) {
-    const { _id } = { ...auth }
+    const { _id, isSubAccount } = { ...auth }
 
     if (!Number.isInteger(_id)) {
       throw new AuthError()
+    }
+    if (
+      methodColl.name === TABLES_NAMES.LEDGERS &&
+      isSubAccount
+    ) {
+      filter._isBalanceRecalced = 1
     }
 
     filter.user_id = _id

--- a/workers/loc.api/sync/dao/helpers/get-where-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-where-query.js
@@ -269,9 +269,9 @@ const _getWhereQueryAndValues = (
     : _fieldNameForStartEnd
   const _filter = _isSetCondName
     ? {
-      ...filter,
-      [_fieldNameWithCondName]: filter[condName]
-    }
+        ...filter,
+        [_fieldNameWithCondName]: filter[condName]
+      }
     : { ...filter }
   const {
     key: _key,
@@ -470,7 +470,8 @@ module.exports = (
       return subQuery
     },
     (isNotSetWhereClause || keys.length === 0)
-      ? '' : `${SQL_OPERATORS.WHERE} `
+      ? ''
+      : `${SQL_OPERATORS.WHERE} `
   )
 
   return { where, values }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -4,5 +4,6 @@ module.exports = {
   WALLETS: 'getWallets',
   BALANCE_HISTORY: 'getBalanceHistory',
   WIN_LOSS: 'getWinLoss',
-  POSITIONS_SNAPSHOT: 'getPositionsSnapshot'
+  POSITIONS_SNAPSHOT: 'getPositionsSnapshot',
+  FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  WALLETS: 'getWallets'
+}

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -1,5 +1,6 @@
 'use strict'
 
 module.exports = {
-  WALLETS: 'getWallets'
+  WALLETS: 'getWallets',
+  BALANCE_HISTORY: 'getBalanceHistory'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -6,5 +6,6 @@ module.exports = {
   WIN_LOSS: 'getWinLoss',
   POSITIONS_SNAPSHOT: 'getPositionsSnapshot',
   FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport',
-  FULL_TAX_REPORT: 'getFullTaxReport'
+  FULL_TAX_REPORT: 'getFullTaxReport',
+  TRADED_VOLUME: 'getTradedVolume'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -5,5 +5,6 @@ module.exports = {
   BALANCE_HISTORY: 'getBalanceHistory',
   WIN_LOSS: 'getWinLoss',
   POSITIONS_SNAPSHOT: 'getPositionsSnapshot',
-  FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport'
+  FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport',
+  FULL_TAX_REPORT: 'getFullTaxReport'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -8,5 +8,6 @@ module.exports = {
   FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport',
   FULL_TAX_REPORT: 'getFullTaxReport',
   TRADED_VOLUME: 'getTradedVolume',
-  FEES_REPORT: 'getFeesReport'
+  FEES_REPORT: 'getFeesReport',
+  PERFORMING_LOAN: 'getPerformingLoan'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -3,5 +3,6 @@
 module.exports = {
   WALLETS: 'getWallets',
   BALANCE_HISTORY: 'getBalanceHistory',
-  WIN_LOSS: 'getWinLoss'
+  WIN_LOSS: 'getWinLoss',
+  POSITIONS_SNAPSHOT: 'getPositionsSnapshot'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -7,5 +7,6 @@ module.exports = {
   POSITIONS_SNAPSHOT: 'getPositionsSnapshot',
   FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport',
   FULL_TAX_REPORT: 'getFullTaxReport',
-  TRADED_VOLUME: 'getTradedVolume'
+  TRADED_VOLUME: 'getTradedVolume',
+  FEES_REPORT: 'getFeesReport'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   WALLETS: 'getWallets',
-  BALANCE_HISTORY: 'getBalanceHistory'
+  BALANCE_HISTORY: 'getBalanceHistory',
+  WIN_LOSS: 'getWinLoss'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -18,8 +18,18 @@ class Checkers {
     this.syncCollsManager = syncCollsManager
   }
 
-  // TODO:
-  [CHECKER_NAMES.WALLETS] (auth) {}
+  [CHECKER_NAMES.WALLETS] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const TYPES = require('../../di/types')
+const CHECKER_NAMES = require('./checker.names')
+
+class Checkers {
+  constructor (
+    SYNC_API_METHODS,
+    syncCollsManager
+  ) {
+    this.SYNC_API_METHODS = SYNC_API_METHODS
+    this.syncCollsManager = syncCollsManager
+  }
+
+  // TODO:
+  [CHECKER_NAMES.WALLETS] (auth) {}
+}
+
+decorate(injectable(), Checkers)
+decorate(inject(TYPES.SYNC_API_METHODS), Checkers, 0)
+decorate(inject(TYPES.SyncCollsManager), Checkers, 1)
+
+module.exports = Checkers

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -72,6 +72,21 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.FULL_SNAPSHOT_REPORT] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES,
+            this.SYNC_API_METHODS.POSITIONS_SNAPSHOT,
+            this.SYNC_API_METHODS.POSITIONS_HISTORY
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -116,6 +116,19 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.FEES_REPORT] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.TRADES,
+            this.SYNC_API_METHODS.CANDLES
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -30,6 +30,19 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.BALANCE_HISTORY] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -1,14 +1,13 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../di/types')
 const CHECKER_NAMES = require('./checker.names')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.SYNC_API_METHODS,
+  TYPES.SyncCollsManager
+]
 class Checkers {
   constructor (
     SYNC_API_METHODS,
@@ -163,8 +162,6 @@ class Checkers {
   }
 }
 
-decorate(injectable(), Checkers)
-decorate(inject(TYPES.SYNC_API_METHODS), Checkers, 0)
-decorate(inject(TYPES.SyncCollsManager), Checkers, 1)
+decorateInjectable(Checkers, depsTypes)
 
 module.exports = Checkers

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -87,6 +87,22 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.FULL_TAX_REPORT] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES,
+            this.SYNC_API_METHODS.MOVEMENTS,
+            this.SYNC_API_METHODS.POSITIONS_SNAPSHOT,
+            this.SYNC_API_METHODS.POSITIONS_HISTORY
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -58,6 +58,20 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.POSITIONS_SNAPSHOT] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.CANDLES,
+            this.SYNC_API_METHODS.POSITIONS_SNAPSHOT,
+            this.SYNC_API_METHODS.POSITIONS_HISTORY
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -129,6 +129,38 @@ class Checkers {
         }
       })
   }
+
+  async [CHECKER_NAMES.PERFORMING_LOAN] (auth) {
+    const {
+      _id: userId,
+      subUsers,
+      isSubAccount
+    } = { ...auth }
+
+    if (!isSubAccount) {
+      return this.syncCollsManager
+        .hasCollBeenSyncedAtLeastOnce({
+          userId,
+          collName: this.SYNC_API_METHODS.LEDGERS
+        })
+    }
+
+    for (const subUser of subUsers) {
+      const { _id: subUserId } = { ...subUser }
+      const isValid = await this.syncCollsManager
+        .hasCollBeenSyncedAtLeastOnce({
+          userId,
+          subUserId,
+          collName: this.SYNC_API_METHODS.LEDGERS
+        })
+
+      if (!isValid) {
+        return false
+      }
+    }
+
+    return true
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -43,6 +43,21 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.WIN_LOSS] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES,
+            this.SYNC_API_METHODS.MOVEMENTS,
+            this.SYNC_API_METHODS.POSITIONS_SNAPSHOT
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -103,6 +103,19 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.TRADED_VOLUME] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.TRADES,
+            this.SYNC_API_METHODS.CANDLES
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const TYPES = require('../../di/types')
+
+class DataConsistencyChecker {
+  constructor (
+    SYNC_API_METHODS,
+    syncCollsManager
+  ) {
+    this.SYNC_API_METHODS = SYNC_API_METHODS
+    this.syncCollsManager = syncCollsManager
+  }
+
+  // TODO:
+  async check (checkerName, args) {}
+}
+
+decorate(injectable(), DataConsistencyChecker)
+decorate(inject(TYPES.SYNC_API_METHODS), DataConsistencyChecker, 0)
+decorate(inject(TYPES.SyncCollsManager), DataConsistencyChecker, 1)
+
+module.exports = DataConsistencyChecker

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -7,7 +7,8 @@ const {
 } = require('inversify')
 
 const {
-  DataConsistencyCheckerFindingError
+  DataConsistencyCheckerFindingError,
+  DataConsistencyError
 } = require('../../errors')
 
 const TYPES = require('../../di/types')
@@ -19,7 +20,6 @@ class DataConsistencyChecker {
     this.checkers = checkers
   }
 
-  // TODO:
   async check (checkerName, args) {
     if (
       !checkerName ||
@@ -39,7 +39,7 @@ class DataConsistencyChecker {
     const isValid = await check(auth)
 
     if (!isValid) {
-      throw new Error('ERR_') // TODO:
+      throw new DataConsistencyError()
     }
   }
 }

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -1,18 +1,15 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const {
   DataConsistencyCheckerFindingError,
   DataConsistencyError
 } = require('../../errors')
 
-const TYPES = require('../../di/types')
+const { decorateInjectable } = require('../../di/utils')
 
+const depsTypes = (TYPES) => [
+  TYPES.Checkers
+]
 class DataConsistencyChecker {
   constructor (
     checkers
@@ -44,7 +41,6 @@ class DataConsistencyChecker {
   }
 }
 
-decorate(injectable(), DataConsistencyChecker)
-decorate(inject(TYPES.Checkers), DataConsistencyChecker, 0)
+decorateInjectable(DataConsistencyChecker, depsTypes)
 
 module.exports = DataConsistencyChecker

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -10,19 +10,37 @@ const TYPES = require('../../di/types')
 
 class DataConsistencyChecker {
   constructor (
-    SYNC_API_METHODS,
-    syncCollsManager
+    checkers
   ) {
-    this.SYNC_API_METHODS = SYNC_API_METHODS
-    this.syncCollsManager = syncCollsManager
+    this.checkers = checkers
   }
 
   // TODO:
-  async check (checkerName, args) {}
+  async check (checkerName, args) {
+    if (
+      !checkerName ||
+      typeof checkerName !== 'string'
+    ) {
+      throw new Error('ERR_') // TODO:
+    }
+
+    const checker = this.checkers[checkerName]
+
+    if (typeof checker !== 'function') {
+      throw new Error('ERR_') // TODO:
+    }
+
+    const { auth } = { ...args }
+    const check = checker.bind(this.checkers)
+    const isValid = await check(auth)
+
+    if (!isValid) {
+      throw new Error('ERR_') // TODO:
+    }
+  }
 }
 
 decorate(injectable(), DataConsistencyChecker)
-decorate(inject(TYPES.SYNC_API_METHODS), DataConsistencyChecker, 0)
-decorate(inject(TYPES.SyncCollsManager), DataConsistencyChecker, 1)
+decorate(inject(TYPES.Checkers), DataConsistencyChecker, 0)
 
 module.exports = DataConsistencyChecker

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -6,6 +6,10 @@ const {
   inject
 } = require('inversify')
 
+const {
+  DataConsistencyCheckerFindingError
+} = require('../../errors')
+
 const TYPES = require('../../di/types')
 
 class DataConsistencyChecker {
@@ -21,13 +25,13 @@ class DataConsistencyChecker {
       !checkerName ||
       typeof checkerName !== 'string'
     ) {
-      throw new Error('ERR_') // TODO:
+      throw new DataConsistencyCheckerFindingError()
     }
 
     const checker = this.checkers[checkerName]
 
     if (typeof checker !== 'function') {
-      throw new Error('ERR_') // TODO:
+      throw new DataConsistencyCheckerFindingError()
     }
 
     const { auth } = { ...args }

--- a/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
@@ -1,12 +1,5 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../../di/types')
 const SYNC_API_METHODS = require('../../schema/sync.api.methods')
 const {
   addPropsToResIfExist,
@@ -14,6 +7,11 @@ const {
   getCategoryFromDescription
 } = require('./helpers')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.SearchClosePriceAndSumAmount
+]
 class ApiMiddlewareHandlerAfter {
   constructor (
     searchClosePriceAndSumAmount
@@ -178,7 +176,6 @@ class ApiMiddlewareHandlerAfter {
   }
 }
 
-decorate(injectable(), ApiMiddlewareHandlerAfter)
-decorate(inject(TYPES.SearchClosePriceAndSumAmount), ApiMiddlewareHandlerAfter, 0)
+decorateInjectable(ApiMiddlewareHandlerAfter, depsTypes)
 
 module.exports = ApiMiddlewareHandlerAfter

--- a/workers/loc.api/sync/data.inserter/api.middleware/index.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/index.js
@@ -3,14 +3,13 @@
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../../di/types')
+const { decorateInjectable } = require('../../../di/utils')
 
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.ApiMiddlewareHandlerAfter
+]
 class ApiMiddleware {
   constructor (
     rService,
@@ -58,8 +57,6 @@ class ApiMiddleware {
   }
 }
 
-decorate(injectable(), ApiMiddleware)
-decorate(inject(TYPES.RService), ApiMiddleware, 0)
-decorate(inject(TYPES.ApiMiddlewareHandlerAfter), ApiMiddleware, 1)
+decorateInjectable(ApiMiddleware, depsTypes)
 
 module.exports = ApiMiddleware

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -73,7 +73,7 @@ class DataChecker {
   }
 
   async checkNewData (auth) {
-    const methodCollMap = this._getMethodCollMap()
+    const methodCollMap = this.getMethodCollMap()
 
     if (this._isInterrupted) {
       return filterMethodCollMap(methodCollMap)
@@ -85,7 +85,7 @@ class DataChecker {
   }
 
   async checkNewPublicData () {
-    const methodCollMap = this._getMethodCollMap()
+    const methodCollMap = this.getMethodCollMap()
 
     if (this._isInterrupted) {
       return filterMethodCollMap(methodCollMap, true)
@@ -260,7 +260,7 @@ class DataChecker {
       if (schema.name === this.ALLOWED_COLLS.CANDLES) {
         schema.hasNewData = false
 
-        await this._checkNewCandlesData(method, schema)
+        await this.checkNewCandlesData(method, schema)
         await this._checkNewConfigurablePublicData(method, schema)
 
         continue
@@ -451,7 +451,7 @@ class DataChecker {
     })
   }
 
-  async _checkNewCandlesData (
+  async checkNewCandlesData (
     method,
     schema
   ) {
@@ -715,7 +715,7 @@ class DataChecker {
     })
   }
 
-  _getMethodCollMap () {
+  getMethodCollMap () {
     return new Map(this._methodCollMap)
   }
 

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -207,6 +207,12 @@ class DataChecker {
         startConf
       )
 
+      if (!schema.hasNewData) {
+        await this.syncCollsManager.setCollAsSynced({
+          collName: method, userId: _id, subUserId
+        })
+      }
+
       return
     }
 
@@ -428,6 +434,21 @@ class DataChecker {
         timeframe
       )
     }
+
+    if (schema.hasNewData) {
+      return
+    }
+
+    const hasCollBeenSyncedAtLeastOnce = await this.syncCollsManager
+      .hasCollBeenSyncedAtLeastOnce({ collName: method })
+
+    if (!hasCollBeenSyncedAtLeastOnce) {
+      return
+    }
+
+    await this.syncCollsManager.setCollAsSynced({
+      collName: method
+    })
   }
 
   async _checkNewCandlesData (
@@ -677,6 +698,21 @@ class DataChecker {
         CANDLES_TIMEFRAME
       )
     }
+
+    if (schema.hasNewData) {
+      return
+    }
+
+    const hasCollBeenSyncedAtLeastOnce = await this.syncCollsManager
+      .hasCollBeenSyncedAtLeastOnce({ collName: method })
+
+    if (!hasCollBeenSyncedAtLeastOnce) {
+      return
+    }
+
+    await this.syncCollsManager.setCollAsSynced({
+      collName: method
+    })
   }
 
   _getMethodCollMap () {

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -45,7 +45,8 @@ class DataChecker {
     ALLOWED_COLLS,
     FOREX_SYMBS,
     currencyConverter,
-    syncInterrupter
+    syncInterrupter,
+    syncCollsManager
   ) {
     this.rService = rService
     this.dao = dao
@@ -55,6 +56,7 @@ class DataChecker {
     this.FOREX_SYMBS = FOREX_SYMBS
     this.currencyConverter = currencyConverter
     this.syncInterrupter = syncInterrupter
+    this.syncCollsManager = syncCollsManager
 
     this._methodCollMap = new Map()
 
@@ -191,15 +193,13 @@ class DataChecker {
       startConf.currStart = lastDateInDb + 1
     }
 
-    const completedColl = await this.dao.getElemInCollBy(
-      this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
-      {
-        user_id: _id,
+    const hasCollBeenSyncedAtLeastOnce = await this.syncCollsManager
+      .hasCollBeenSyncedAtLeastOnce({
+        userId: _id,
         collName: method
-      }
-    )
+      })
 
-    if (!isEmpty(completedColl)) {
+    if (hasCollBeenSyncedAtLeastOnce) {
       pushConfigurableDataStartConf(
         schema,
         ALL_SYMBOLS_TO_SYNC,
@@ -714,5 +714,6 @@ decorate(inject(TYPES.ALLOWED_COLLS), DataChecker, 4)
 decorate(inject(TYPES.FOREX_SYMBS), DataChecker, 5)
 decorate(inject(TYPES.CurrencyConverter), DataChecker, 6)
 decorate(inject(TYPES.SyncInterrupter), DataChecker, 7)
+decorate(inject(TYPES.SyncCollsManager), DataChecker, 8)
 
 module.exports = DataChecker

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -196,6 +196,7 @@ class DataChecker {
     const hasCollBeenSyncedAtLeastOnce = await this.syncCollsManager
       .hasCollBeenSyncedAtLeastOnce({
         userId: _id,
+        subUserId,
         collName: method
       })
 

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -10,13 +10,7 @@ const {
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../../di/types')
 const {
   getMethodArgMap
 } = require('../helpers')
@@ -36,6 +30,19 @@ const {
   ALL_SYMBOLS_TO_SYNC
 } = require('../const')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.TABLES_NAMES,
+  TYPES.ALLOWED_COLLS,
+  TYPES.FOREX_SYMBS,
+  TYPES.CurrencyConverter,
+  TYPES.SyncInterrupter,
+  TYPES.SyncCollsManager
+]
 class DataChecker {
   constructor (
     rService,
@@ -756,15 +763,6 @@ class DataChecker {
   }
 }
 
-decorate(injectable(), DataChecker)
-decorate(inject(TYPES.RService), DataChecker, 0)
-decorate(inject(TYPES.DAO), DataChecker, 1)
-decorate(inject(TYPES.SyncSchema), DataChecker, 2)
-decorate(inject(TYPES.TABLES_NAMES), DataChecker, 3)
-decorate(inject(TYPES.ALLOWED_COLLS), DataChecker, 4)
-decorate(inject(TYPES.FOREX_SYMBS), DataChecker, 5)
-decorate(inject(TYPES.CurrencyConverter), DataChecker, 6)
-decorate(inject(TYPES.SyncInterrupter), DataChecker, 7)
-decorate(inject(TYPES.SyncCollsManager), DataChecker, 8)
+decorateInjectable(DataChecker, depsTypes)
 
 module.exports = DataChecker

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -296,14 +296,14 @@ class DataChecker {
 
     const params = name === this.ALLOWED_COLLS.CANDLES
       ? {
-        section: CANDLES_SECTION,
-        notThrowError: true,
-        notCheckNextPage: true
-      }
+          section: CANDLES_SECTION,
+          notThrowError: true,
+          notCheckNextPage: true
+        }
       : {
-        notThrowError: true,
-        notCheckNextPage: true
-      }
+          notThrowError: true,
+          notCheckNextPage: true
+        }
 
     for (const confs of publicСollsСonf) {
       if (this._isInterrupted) {

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -68,8 +68,7 @@ class DataChecker {
       this._isInterrupted = true
     })
 
-    this._methodCollMap = this.syncSchema
-      .getMethodCollMap(methodCollMap)
+    this.setMethodCollMap(methodCollMap)
   }
 
   async checkNewData (auth) {
@@ -122,7 +121,7 @@ class DataChecker {
       return
     }
 
-    schema.hasNewData = false
+    this._resetSyncSchemaProps(schema)
 
     const args = this._getMethodArgMap(method, { auth, limit: 1 })
     args.params.notThrowError = true
@@ -251,16 +250,11 @@ class DataChecker {
         schema.name === this.ALLOWED_COLLS.PUBLIC_TRADES ||
         schema.name === this.ALLOWED_COLLS.TICKERS_HISTORY
       ) {
-        schema.hasNewData = false
-
         await this._checkNewConfigurablePublicData(method, schema)
 
         continue
       }
       if (schema.name === this.ALLOWED_COLLS.CANDLES) {
-        schema.hasNewData = false
-        schema.start = []
-
         if (!schema.isSyncDoneForCurrencyConv) {
           await this.checkNewCandlesData(method, schema)
 
@@ -278,6 +272,8 @@ class DataChecker {
     if (this._isInterrupted) {
       return
     }
+
+    this._resetSyncSchemaProps(schema)
 
     const {
       confName,
@@ -464,6 +460,8 @@ class DataChecker {
     if (this._isInterrupted) {
       return
     }
+
+    this._resetSyncSchemaProps(schema)
 
     const {
       symbolFieldName,
@@ -723,6 +721,16 @@ class DataChecker {
 
   getMethodCollMap () {
     return new Map(this._methodCollMap)
+  }
+
+  setMethodCollMap (methodCollMap) {
+    this._methodCollMap = this.syncSchema
+      .getMethodCollMap(methodCollMap)
+  }
+
+  _resetSyncSchemaProps (schema) {
+    schema.hasNewData = false
+    schema.start = []
   }
 
   _getMethodArgMap (method, opts) {

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -259,8 +259,14 @@ class DataChecker {
       }
       if (schema.name === this.ALLOWED_COLLS.CANDLES) {
         schema.hasNewData = false
+        schema.start = []
 
-        await this.checkNewCandlesData(method, schema)
+        if (!schema.isSyncDoneForCurrencyConv) {
+          await this.checkNewCandlesData(method, schema)
+
+          schema.isSyncDoneForCurrencyConv = true
+        }
+
         await this._checkNewConfigurablePublicData(method, schema)
 
         continue

--- a/workers/loc.api/sync/data.inserter/helpers/get-method-arg-map.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-method-arg-map.js
@@ -25,10 +25,10 @@ module.exports = (
     typeof subUserApiSecret === 'string'
   )
     ? {
-      apiKey: subUserApiKey,
-      apiSecret: subUserApiSecret,
-      session: reqAuth
-    }
+        apiKey: subUserApiKey,
+        apiSecret: subUserApiSecret,
+        session: reqAuth
+      }
     : { apiKey, apiSecret, session: reqAuth }
 
   return {

--- a/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { upperCase, snakeCase } = require('lodash')
+
+module.exports = (method) => {
+  const name = method.replace(/^[^A-Z]+/, '')
+  const upperCaseName = upperCase(name)
+  const snakeCaseName = snakeCase(upperCaseName)
+
+  return snakeCaseName
+}

--- a/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const { upperCase, snakeCase } = require('lodash')
+const { snakeCase } = require('lodash')
 
 module.exports = (method) => {
   const name = method.replace(/^[^A-Z]+/, '')
-  const upperCaseName = upperCase(name)
-  const snakeCaseName = snakeCase(upperCaseName)
+  const snakeCaseName = snakeCase(name)
+  const upperCaseName = snakeCaseName.toUpperCase()
 
-  return snakeCaseName
+  return upperCaseName
 }

--- a/workers/loc.api/sync/data.inserter/helpers/index.js
+++ b/workers/loc.api/sync/data.inserter/helpers/index.js
@@ -12,6 +12,7 @@ const {
   getAllowedCollsNames
 } = require('./utils')
 const getMethodArgMap = require('./get-method-arg-map')
+const getSyncCollName = require('./get-sync-coll-name')
 
 module.exports = {
   searchClosePriceAndSumAmount,
@@ -19,5 +20,6 @@ module.exports = {
   normalizeApiData,
   getAuthFromDb,
   getAllowedCollsNames,
-  getMethodArgMap
+  getMethodArgMap,
+  getSyncCollName
 }

--- a/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
@@ -55,12 +55,16 @@ class ConvertCurrencyHook extends DataInserterHook {
   /**
    * @override
    */
-  async execute () {
+  async execute (names = []) {
+    const _names = Array.isArray(names)
+      ? names
+      : [names]
     const { syncColls } = this._opts
 
     if (syncColls.every(name => (
       name !== this.ALLOWED_COLLS.ALL &&
-      name !== this.ALLOWED_COLLS.CANDLES
+      name !== this.ALLOWED_COLLS.CANDLES &&
+      name !== this.ALLOWED_COLLS.LEDGERS
     ))) {
       return
     }
@@ -68,6 +72,15 @@ class ConvertCurrencyHook extends DataInserterHook {
     const convSchema = this._getConvSchema()
 
     for (const [collName, schema] of convSchema) {
+      if (_names.length > 0) {
+        const isSkipped = _names.every((name) => (
+          !name ||
+          name !== collName
+        ))
+
+        if (isSkipped) continue
+      }
+
       let count = 0
       let _id = 0
 

--- a/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
@@ -1,15 +1,15 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../../di/types')
 const { CONVERT_TO } = require('../const')
 const DataInserterHook = require('./data.inserter.hook')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.CurrencyConverter,
+  TYPES.ALLOWED_COLLS
+]
 class ConvertCurrencyHook extends DataInserterHook {
   constructor (
     dao,
@@ -139,9 +139,6 @@ class ConvertCurrencyHook extends DataInserterHook {
   }
 }
 
-decorate(injectable(), ConvertCurrencyHook)
-decorate(inject(TYPES.DAO), ConvertCurrencyHook, 0)
-decorate(inject(TYPES.CurrencyConverter), ConvertCurrencyHook, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), ConvertCurrencyHook, 2)
+decorateInjectable(ConvertCurrencyHook, depsTypes)
 
 module.exports = ConvertCurrencyHook

--- a/workers/loc.api/sync/data.inserter/hooks/data.inserter.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/data.inserter.hook.js
@@ -1,13 +1,10 @@
 'use strict'
 
 const {
-  decorate,
-  injectable
-} = require('inversify')
-
-const {
   ImplementationError
 } = require('../../../errors')
+
+const { decorateInjectable } = require('../../../di/utils')
 
 class DataInserterHook {
   constructor () {
@@ -44,6 +41,6 @@ class DataInserterHook {
   async execute () { throw new ImplementationError() }
 }
 
-decorate(injectable(), DataInserterHook)
+decorateInjectable(DataInserterHook)
 
 module.exports = DataInserterHook

--- a/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
@@ -2,18 +2,17 @@
 
 const { orderBy } = require('lodash')
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../../di/types')
 const DataInserterHook = require('./data.inserter.hook')
 const {
   SubAccountLedgersBalancesRecalcError
 } = require('../../../errors')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES
+]
 class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
   constructor (
     dao,
@@ -353,8 +352,6 @@ class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
   }
 }
 
-decorate(injectable(), RecalcSubAccountLedgersBalancesHook)
-decorate(inject(TYPES.DAO), RecalcSubAccountLedgersBalancesHook, 0)
-decorate(inject(TYPES.TABLES_NAMES), RecalcSubAccountLedgersBalancesHook, 1)
+decorateInjectable(RecalcSubAccountLedgersBalancesHook, depsTypes)
 
 module.exports = RecalcSubAccountLedgersBalancesHook

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -174,7 +174,7 @@ class DataInserter extends EventEmitter {
     await this.insertNewPublicDataToDb(progress)
 
     await this.wsEventEmitter
-      .emitSyncingStep(() => 'DB_PREPARATION')
+      .emitSyncingStep('DB_PREPARATION')
     await this._afterAllInserts()
 
     if (typeof this.dao.optimize === 'function') {
@@ -236,7 +236,7 @@ class DataInserter extends EventEmitter {
     }
 
     await this.wsEventEmitter
-      .emitSyncingStep(() => 'CHECKING_NEW_PUBLIC_DATA')
+      .emitSyncingStep('CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewPublicData()
     const size = methodCollMap.size
@@ -249,9 +249,8 @@ class DataInserter extends EventEmitter {
         return
       }
 
-      await this.wsEventEmitter.emitSyncingStep(
-        () => `SYNCING_${getSyncCollName(method)}`
-      )
+      await this.wsEventEmitter
+        .emitSyncingStep(`SYNCING_${getSyncCollName(method)}`)
 
       await this._updateApiDataArrObjTypeToDb(method, item)
       await this._updateApiDataArrTypeToDb(method, item)
@@ -281,11 +280,10 @@ class DataInserter extends EventEmitter {
       return userProgress
     }
 
-    await this.wsEventEmitter
-      .emitSyncingStepToOne(
-        () => 'CHECKING_NEW_PRIVATE_DATA',
-        auth
-      )
+    await this.wsEventEmitter.emitSyncingStepToOne(
+      'CHECKING_NEW_PRIVATE_DATA',
+      auth
+    )
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
@@ -299,7 +297,7 @@ class DataInserter extends EventEmitter {
       }
 
       await this.wsEventEmitter.emitSyncingStepToOne(
-        () => `SYNCING_${getSyncCollName(method)}`,
+        `SYNCING_${getSyncCollName(method)}`,
         auth
       )
 

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -27,7 +27,8 @@ const {
   normalizeApiData,
   getAuthFromDb,
   getAllowedCollsNames,
-  getMethodArgMap
+  getMethodArgMap,
+  getSyncCollName
 } = require('./helpers')
 const DataInserterHook = require('./hooks/data.inserter.hook')
 const {
@@ -58,7 +59,8 @@ class DataInserter extends EventEmitter {
     convertCurrencyHook,
     recalcSubAccountLedgersBalancesHook,
     dataChecker,
-    syncInterrupter
+    syncInterrupter,
+    wsEventEmitter
   ) {
     super()
 
@@ -74,6 +76,7 @@ class DataInserter extends EventEmitter {
     this.recalcSubAccountLedgersBalancesHook = recalcSubAccountLedgersBalancesHook
     this.dataChecker = dataChecker
     this.syncInterrupter = syncInterrupter
+    this.wsEventEmitter = wsEventEmitter
 
     this._asyncProgressHandlers = []
     this._auth = null
@@ -170,6 +173,8 @@ class DataInserter extends EventEmitter {
 
     await this.insertNewPublicDataToDb(progress)
 
+    await this.wsEventEmitter
+      .emitSyncingStep(() => 'DB_PREPARATION')
     await this._afterAllInserts()
 
     if (typeof this.dao.optimize === 'function') {
@@ -230,6 +235,8 @@ class DataInserter extends EventEmitter {
       return
     }
 
+    await this.wsEventEmitter
+      .emitSyncingStepToOne(() => 'CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewPublicData()
     const size = methodCollMap.size
@@ -241,6 +248,10 @@ class DataInserter extends EventEmitter {
       if (this._isInterrupted) {
         return
       }
+
+      await this.wsEventEmitter.emitSyncingStepToOne(
+        () => `SYNCING_${getSyncCollName(method)}`
+      )
 
       await this._updateApiDataArrObjTypeToDb(method, item)
       await this._updateApiDataArrTypeToDb(method, item)
@@ -270,6 +281,8 @@ class DataInserter extends EventEmitter {
       return userProgress
     }
 
+    await this.wsEventEmitter
+      .emitSyncingStepToOne(() => 'CHECKING_NEW_PRIVATE_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
@@ -281,6 +294,10 @@ class DataInserter extends EventEmitter {
       if (this._isInterrupted) {
         return userProgress
       }
+
+      await this.wsEventEmitter.emitSyncingStepToOne(
+        () => `SYNCING_${getSyncCollName(method)}`
+      )
 
       const { start } = schema
 
@@ -822,5 +839,6 @@ decorate(inject(TYPES.ConvertCurrencyHook), DataInserter, 8)
 decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 9)
 decorate(inject(TYPES.DataChecker), DataInserter, 10)
 decorate(inject(TYPES.SyncInterrupter), DataInserter, 11)
+decorate(inject(TYPES.WSEventEmitter), DataInserter, 12)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -399,6 +399,8 @@ class DataInserter extends EventEmitter {
       collName: this.SYNC_API_METHODS.CANDLES
     })
 
+    candlesSchema.isSyncDoneForCurrencyConv = true
+
     await this.convertCurrencyHook.execute(
       this.ALLOWED_COLLS.LEDGERS
     )

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -60,7 +60,8 @@ class DataInserter extends EventEmitter {
     recalcSubAccountLedgersBalancesHook,
     dataChecker,
     syncInterrupter,
-    wsEventEmitter
+    wsEventEmitter,
+    syncCollsManager
   ) {
     super()
 
@@ -77,6 +78,7 @@ class DataInserter extends EventEmitter {
     this.dataChecker = dataChecker
     this.syncInterrupter = syncInterrupter
     this.wsEventEmitter = wsEventEmitter
+    this.syncCollsManager = syncCollsManager
 
     this._asyncProgressHandlers = []
     this._auth = null
@@ -333,14 +335,10 @@ class DataInserter extends EventEmitter {
         ) {
           const { _id } = { ...auth }
 
-          await this.dao.insertElemToDb(
-            this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
-            {
-              collName: method,
-              user_id: _id
-            },
-            { isReplacedIfExists: true }
-          )
+          await this.syncCollsManager.setCollAsSynced({
+            collName: method,
+            user_id: _id
+          })
         }
       }
 
@@ -842,5 +840,6 @@ decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 9)
 decorate(inject(TYPES.DataChecker), DataInserter, 10)
 decorate(inject(TYPES.SyncInterrupter), DataInserter, 11)
 decorate(inject(TYPES.WSEventEmitter), DataInserter, 12)
+decorate(inject(TYPES.SyncCollsManager), DataInserter, 12)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -236,7 +236,7 @@ class DataInserter extends EventEmitter {
     }
 
     await this.wsEventEmitter
-      .emitSyncingStepToOne(() => 'CHECKING_NEW_PUBLIC_DATA')
+      .emitSyncingStep(() => 'CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
       .checkNewPublicData()
     const size = methodCollMap.size
@@ -249,7 +249,7 @@ class DataInserter extends EventEmitter {
         return
       }
 
-      await this.wsEventEmitter.emitSyncingStepToOne(
+      await this.wsEventEmitter.emitSyncingStep(
         () => `SYNCING_${getSyncCollName(method)}`
       )
 
@@ -282,7 +282,10 @@ class DataInserter extends EventEmitter {
     }
 
     await this.wsEventEmitter
-      .emitSyncingStepToOne(() => 'CHECKING_NEW_PRIVATE_DATA')
+      .emitSyncingStepToOne(
+        () => 'CHECKING_NEW_PRIVATE_DATA',
+        auth
+      )
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
@@ -296,7 +299,8 @@ class DataInserter extends EventEmitter {
       }
 
       await this.wsEventEmitter.emitSyncingStepToOne(
-        () => `SYNCING_${getSyncCollName(method)}`
+        () => `SYNCING_${getSyncCollName(method)}`,
+        auth
       )
 
       const { start } = schema

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -54,6 +54,7 @@ class DataInserter extends EventEmitter {
     syncSchema,
     TABLES_NAMES,
     ALLOWED_COLLS,
+    SYNC_API_METHODS,
     FOREX_SYMBS,
     authenticator,
     convertCurrencyHook,
@@ -71,6 +72,7 @@ class DataInserter extends EventEmitter {
     this.syncSchema = syncSchema
     this.TABLES_NAMES = TABLES_NAMES
     this.ALLOWED_COLLS = ALLOWED_COLLS
+    this.SYNC_API_METHODS = SYNC_API_METHODS
     this.FOREX_SYMBS = FOREX_SYMBS
     this.authenticator = authenticator
     this.convertCurrencyHook = convertCurrencyHook
@@ -82,6 +84,7 @@ class DataInserter extends EventEmitter {
 
     this._asyncProgressHandlers = []
     this._auth = null
+    this._syncedSubUsers = []
     this._allowedCollsNames = getAllowedCollsNames(
       this.ALLOWED_COLLS
     )
@@ -293,8 +296,22 @@ class DataInserter extends EventEmitter {
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
-    const { _id: userId, subUser } = { ...auth }
+    const {
+      _id: userId,
+      subUser,
+      subUsers,
+      isSubAccount
+    } = { ...auth }
     const { _id: subUserId } = { ...subUser }
+    const isLastSubUser = (
+      isSubAccount &&
+      subUsers.every((id) => (
+        [
+          ...this._syncedSubUsers,
+          subUserId
+        ].some((suId) => id === suId)
+      ))
+    )
 
     let count = 0
     let progress = 0
@@ -333,9 +350,16 @@ class DataInserter extends EventEmitter {
         )
       }
 
+      await this._prepareLedgers(method, { isLastSubUser })
+      await this._prepareMovements(method)
+
       await this.syncCollsManager.setCollAsSynced({
         collName: method, userId, subUserId
       })
+
+      if (isSubAccount) {
+        this._syncedSubUsers.push(subUserId)
+      }
 
       count += 1
       progress = Math.round(
@@ -348,6 +372,54 @@ class DataInserter extends EventEmitter {
     }
 
     return progress
+  }
+
+  /* If ledgers are syncing
+    sync candles,
+    convert currency,
+    recalc sub-account */
+  async _prepareLedgers (method, { isLastSubUser }) {
+    if (method !== this.SYNC_API_METHODS.LEDGERS) {
+      return
+    }
+
+    const candlesSchema = this.dataChecker
+      .getMethodCollMap().get(this.SYNC_API_METHODS.CANDLES)
+    candlesSchema.hasNewData = false
+
+    await this.dataChecker.checkNewCandlesData(
+      this.SYNC_API_METHODS.CANDLES,
+      candlesSchema
+    )
+    await this._insertApiDataPublicArrObjTypeToDb(
+      this.SYNC_API_METHODS.CANDLES,
+      candlesSchema
+    )
+    await this.syncCollsManager.setCollAsSynced({
+      collName: this.SYNC_API_METHODS.CANDLES
+    })
+
+    await this.convertCurrencyHook.execute(
+      this.ALLOWED_COLLS.LEDGERS
+    )
+
+    if (!isLastSubUser) {
+      return
+    }
+
+    await this.recalcSubAccountLedgersBalancesHook.execute()
+  }
+
+  /* If movements are syncing
+    convert currency */
+  async _prepareMovements (method) {
+    if (method !== this.SYNC_API_METHODS.MOVEMENTS) {
+      return
+    }
+
+    await this.convertCurrencyHook.execute(
+      this.ALLOWED_COLLS.MOVEMENTS
+    )
   }
 
   _getDataFromApi (methodApi, args, isCheckCall) {
@@ -828,13 +900,14 @@ decorate(inject(TYPES.ApiMiddleware), DataInserter, 2)
 decorate(inject(TYPES.SyncSchema), DataInserter, 3)
 decorate(inject(TYPES.TABLES_NAMES), DataInserter, 4)
 decorate(inject(TYPES.ALLOWED_COLLS), DataInserter, 5)
-decorate(inject(TYPES.FOREX_SYMBS), DataInserter, 6)
-decorate(inject(TYPES.Authenticator), DataInserter, 7)
-decorate(inject(TYPES.ConvertCurrencyHook), DataInserter, 8)
-decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 9)
-decorate(inject(TYPES.DataChecker), DataInserter, 10)
-decorate(inject(TYPES.SyncInterrupter), DataInserter, 11)
-decorate(inject(TYPES.WSEventEmitter), DataInserter, 12)
-decorate(inject(TYPES.SyncCollsManager), DataInserter, 13)
+decorate(inject(TYPES.SYNC_API_METHODS), DataInserter, 6)
+decorate(inject(TYPES.FOREX_SYMBS), DataInserter, 7)
+decorate(inject(TYPES.Authenticator), DataInserter, 8)
+decorate(inject(TYPES.ConvertCurrencyHook), DataInserter, 9)
+decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 10)
+decorate(inject(TYPES.DataChecker), DataInserter, 11)
+decorate(inject(TYPES.SyncInterrupter), DataInserter, 12)
+decorate(inject(TYPES.WSEventEmitter), DataInserter, 13)
+decorate(inject(TYPES.SyncCollsManager), DataInserter, 14)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -305,12 +305,14 @@ class DataInserter extends EventEmitter {
     const { _id: subUserId } = { ...subUser }
     const isLastSubUser = (
       isSubAccount &&
-      subUsers.every((id) => (
-        [
+      subUsers.every((subUser) => {
+        const { _id } = { ...subUser }
+
+        return [
           ...this._syncedSubUsers,
           subUserId
-        ].some((suId) => id === suId)
-      ))
+        ].some((suId) => _id === suId)
+      })
     )
 
     let count = 0
@@ -357,10 +359,6 @@ class DataInserter extends EventEmitter {
         collName: method, userId, subUserId
       })
 
-      if (isSubAccount) {
-        this._syncedSubUsers.push(subUserId)
-      }
-
       count += 1
       progress = Math.round(
         (((count / size) * 100) / this._auth.size) + userProgress
@@ -369,6 +367,10 @@ class DataInserter extends EventEmitter {
       if (progress < 100) {
         await this.setProgress(progress)
       }
+    }
+
+    if (isSubAccount) {
+      this._syncedSubUsers.push(subUserId)
     }
 
     return progress

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -11,13 +11,7 @@ const {
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const {
   CANDLES_SECTION,
   ALL_SYMBOLS_TO_SYNC
@@ -46,6 +40,25 @@ const {
 
 const MESS_ERR_UNAUTH = 'ERR_AUTH_UNAUTHORIZED'
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.ApiMiddleware,
+  TYPES.SyncSchema,
+  TYPES.TABLES_NAMES,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SYNC_API_METHODS,
+  TYPES.FOREX_SYMBS,
+  TYPES.Authenticator,
+  TYPES.ConvertCurrencyHook,
+  TYPES.RecalcSubAccountLedgersBalancesHook,
+  TYPES.DataChecker,
+  TYPES.SyncInterrupter,
+  TYPES.WSEventEmitter,
+  TYPES.SyncCollsManager
+]
 class DataInserter extends EventEmitter {
   constructor (
     rService,
@@ -896,21 +909,6 @@ class DataInserter extends EventEmitter {
   }
 }
 
-decorate(injectable(), DataInserter)
-decorate(inject(TYPES.RService), DataInserter, 0)
-decorate(inject(TYPES.DAO), DataInserter, 1)
-decorate(inject(TYPES.ApiMiddleware), DataInserter, 2)
-decorate(inject(TYPES.SyncSchema), DataInserter, 3)
-decorate(inject(TYPES.TABLES_NAMES), DataInserter, 4)
-decorate(inject(TYPES.ALLOWED_COLLS), DataInserter, 5)
-decorate(inject(TYPES.SYNC_API_METHODS), DataInserter, 6)
-decorate(inject(TYPES.FOREX_SYMBS), DataInserter, 7)
-decorate(inject(TYPES.Authenticator), DataInserter, 8)
-decorate(inject(TYPES.ConvertCurrencyHook), DataInserter, 9)
-decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 10)
-decorate(inject(TYPES.DataChecker), DataInserter, 11)
-decorate(inject(TYPES.SyncInterrupter), DataInserter, 12)
-decorate(inject(TYPES.WSEventEmitter), DataInserter, 13)
-decorate(inject(TYPES.SyncCollsManager), DataInserter, 14)
+decorateInjectable(DataInserter, depsTypes)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -293,7 +293,8 @@ class DataInserter extends EventEmitter {
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
-    const { _id: userId } = { ...auth }
+    const { _id: userId, subUser } = { ...auth }
+    const { _id: subUserId } = { ...subUser }
 
     let count = 0
     let progress = 0
@@ -333,7 +334,7 @@ class DataInserter extends EventEmitter {
       }
 
       await this.syncCollsManager.setCollAsSynced({
-        collName: method, userId
+        collName: method, userId, subUserId
       })
 
       count += 1
@@ -834,6 +835,6 @@ decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 9)
 decorate(inject(TYPES.DataChecker), DataInserter, 10)
 decorate(inject(TYPES.SyncInterrupter), DataInserter, 11)
 decorate(inject(TYPES.WSEventEmitter), DataInserter, 12)
-decorate(inject(TYPES.SyncCollsManager), DataInserter, 12)
+decorate(inject(TYPES.SyncCollsManager), DataInserter, 13)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -258,6 +258,10 @@ class DataInserter extends EventEmitter {
       await this._updateApiDataArrTypeToDb(method, item)
       await this._insertApiDataPublicArrObjTypeToDb(method, item)
 
+      await this.syncCollsManager.setCollAsSynced({
+        collName: method
+      })
+
       count += 1
       progress = Math.round(
         prevProgress + (count / size) * 100 * ((100 - prevProgress) / 100)
@@ -289,6 +293,7 @@ class DataInserter extends EventEmitter {
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
+    const { _id: userId } = { ...auth }
 
     let count = 0
     let progress = 0
@@ -306,10 +311,7 @@ class DataInserter extends EventEmitter {
       const { start } = schema
 
       for (const [symbol, dates] of start) {
-        const {
-          baseStartFrom = 0,
-          baseStartTo
-        } = { ...dates }
+        const { baseStartFrom = 0 } = { ...dates }
         const addApiParams = (
           !symbol ||
           symbol === ALL_SYMBOLS_TO_SYNC ||
@@ -328,19 +330,11 @@ class DataInserter extends EventEmitter {
           addApiParams,
           auth
         )
-
-        if (
-          Number.isInteger(baseStartFrom) &&
-          Number.isInteger(baseStartTo)
-        ) {
-          const { _id } = { ...auth }
-
-          await this.syncCollsManager.setCollAsSynced({
-            collName: method,
-            user_id: _id
-          })
-        }
       }
+
+      await this.syncCollsManager.setCollAsSynced({
+        collName: method, userId
+      })
 
       count += 1
       progress = Math.round(

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -389,10 +389,10 @@ class DataInserter extends EventEmitter {
 
         const addApiParams = name === this.ALLOWED_COLLS.CANDLES
           ? {
-            symbol,
-            timeframe,
-            section: CANDLES_SECTION
-          }
+              symbol,
+              timeframe,
+              section: CANDLES_SECTION
+            }
           : { symbol }
 
         await this._insertConfigurableApiData(

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -387,7 +387,6 @@ class DataInserter extends EventEmitter {
 
     const candlesSchema = this.dataChecker
       .getMethodCollMap().get(this.SYNC_API_METHODS.CANDLES)
-    candlesSchema.hasNewData = false
 
     await this.dataChecker.checkNewCandlesData(
       this.SYNC_API_METHODS.CANDLES,

--- a/workers/loc.api/sync/fees.report/index.js
+++ b/workers/loc.api/sync/fees.report/index.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.Trades
+]
 class FeesReport {
   constructor (
     trades
@@ -23,7 +20,6 @@ class FeesReport {
   }
 }
 
-decorate(injectable(), FeesReport)
-decorate(inject(TYPES.Trades), FeesReport, 0)
+decorateInjectable(FeesReport, depsTypes)
 
 module.exports = FeesReport

--- a/workers/loc.api/sync/full.snapshot.report/index.js
+++ b/workers/loc.api/sync/full.snapshot.report/index.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.Wallets,
+  TYPES.PositionsSnapshot
+]
 class FullSnapshotReport {
   constructor (
     wallets,
@@ -149,8 +147,6 @@ class FullSnapshotReport {
   }
 }
 
-decorate(injectable(), FullSnapshotReport)
-decorate(inject(TYPES.Wallets), FullSnapshotReport, 0)
-decorate(inject(TYPES.PositionsSnapshot), FullSnapshotReport, 1)
+decorateInjectable(FullSnapshotReport, depsTypes)
 
 module.exports = FullSnapshotReport

--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -1,16 +1,18 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../di/types')
-const {
   isForexSymb
 } = require('../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.ALLOWED_COLLS,
+  TYPES.FullSnapshotReport,
+  TYPES.Authenticator
+]
 class FullTaxReport {
   constructor (
     dao,
@@ -215,11 +217,6 @@ class FullTaxReport {
   }
 }
 
-decorate(injectable(), FullTaxReport)
-decorate(inject(TYPES.DAO), FullTaxReport, 0)
-decorate(inject(TYPES.SyncSchema), FullTaxReport, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), FullTaxReport, 2)
-decorate(inject(TYPES.FullSnapshotReport), FullTaxReport, 3)
-decorate(inject(TYPES.Authenticator), FullTaxReport, 4)
+decorateInjectable(FullTaxReport, depsTypes)
 
 module.exports = FullTaxReport

--- a/workers/loc.api/sync/helpers/calc-grouped-data.js
+++ b/workers/loc.api/sync/helpers/calc-grouped-data.js
@@ -146,9 +146,9 @@ const _getReducer = (
 
     const data = isSubCalc
       ? {
-        mts: item.mts,
-        vals: Object.assign({}, res)
-      }
+          mts: item.mts,
+          vals: Object.assign({}, res)
+        }
       : Object.assign({ mts: item.mts }, res)
 
     if (isReverse) {

--- a/workers/loc.api/sync/index.js
+++ b/workers/loc.api/sync/index.js
@@ -1,14 +1,17 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../di/types')
 const { CollSyncPermissionError } = require('../errors')
 
+const { decorateInjectable } = require('../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.SyncQueue,
+  TYPES.RService,
+  TYPES.ALLOWED_COLLS,
+  TYPES.Progress,
+  TYPES.RedirectRequestsToApi,
+  TYPES.SyncInterrupter
+]
 class Sync {
   constructor (
     syncQueue,
@@ -124,12 +127,6 @@ class Sync {
   }
 }
 
-decorate(injectable(), Sync)
-decorate(inject(TYPES.SyncQueue), Sync, 0)
-decorate(inject(TYPES.RService), Sync, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), Sync, 2)
-decorate(inject(TYPES.Progress), Sync, 3)
-decorate(inject(TYPES.RedirectRequestsToApi), Sync, 4)
-decorate(inject(TYPES.SyncInterrupter), Sync, 5)
+decorateInjectable(Sync, depsTypes)
 
 module.exports = Sync

--- a/workers/loc.api/sync/order.trades/index.js
+++ b/workers/loc.api/sync/order.trades/index.js
@@ -1,13 +1,14 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.SubAccountApiData,
+  TYPES.RService,
+  TYPES.SYNC_API_METHODS
+]
 class OrderTrades {
   constructor (
     dao,
@@ -96,11 +97,6 @@ class OrderTrades {
   }
 }
 
-decorate(injectable(), OrderTrades)
-decorate(inject(TYPES.DAO), OrderTrades, 0)
-decorate(inject(TYPES.TABLES_NAMES), OrderTrades, 1)
-decorate(inject(TYPES.SubAccountApiData), OrderTrades, 2)
-decorate(inject(TYPES.RService), OrderTrades, 3)
-decorate(inject(TYPES.SYNC_API_METHODS), OrderTrades, 4)
+decorateInjectable(OrderTrades, depsTypes)
 
 module.exports = OrderTrades

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -1,19 +1,22 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../di/types')
-const {
   calcGroupedData,
   groupByTimeframe,
   getStartMtsByTimeframe,
   getBackIterable
 } = require('../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SyncSchema,
+  TYPES.FOREX_SYMBS,
+  TYPES.Authenticator,
+  TYPES.SYNC_API_METHODS
+]
 class PerformingLoan {
   constructor (
     dao,
@@ -412,12 +415,6 @@ class PerformingLoan {
   }
 }
 
-decorate(injectable(), PerformingLoan)
-decorate(inject(TYPES.DAO), PerformingLoan, 0)
-decorate(inject(TYPES.ALLOWED_COLLS), PerformingLoan, 1)
-decorate(inject(TYPES.SyncSchema), PerformingLoan, 2)
-decorate(inject(TYPES.FOREX_SYMBS), PerformingLoan, 3)
-decorate(inject(TYPES.Authenticator), PerformingLoan, 4)
-decorate(inject(TYPES.SYNC_API_METHODS), PerformingLoan, 5)
+decorateInjectable(PerformingLoan, depsTypes)
 
 module.exports = PerformingLoan

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -55,6 +55,9 @@ class PerformingLoan {
     )
       ? { $in: { currency: symbol } }
       : {}
+    const filterToSkipNotRecalcedBalance = user.isSubAccount
+      ? { _isBalanceRecalced: 1 }
+      : {}
 
     return this.dao.getElemsInCollBy(
       this.ALLOWED_COLLS.LEDGERS,
@@ -64,7 +67,8 @@ class PerformingLoan {
           user_id: user._id,
           $lte: { mts: end },
           $gte: { mts: start },
-          ...symbFilter
+          ...symbFilter,
+          ...filterToSkipNotRecalcedBalance
         },
         sort: [['mts', -1]],
         projection,

--- a/workers/loc.api/sync/positions.audit/index.js
+++ b/workers/loc.api/sync/positions.audit/index.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.SubAccountApiData
+]
 class PositionsAudit {
   constructor (
     dao,
@@ -64,9 +63,6 @@ class PositionsAudit {
   }
 }
 
-decorate(injectable(), PositionsAudit)
-decorate(inject(TYPES.DAO), PositionsAudit, 0)
-decorate(inject(TYPES.TABLES_NAMES), PositionsAudit, 1)
-decorate(inject(TYPES.SubAccountApiData), PositionsAudit, 2)
+decorateInjectable(PositionsAudit, depsTypes)
 
 module.exports = PositionsAudit

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -3,21 +3,24 @@
 const { orderBy } = require('lodash')
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   splitSymbolPairs
 } = require('bfx-report/workers/loc.api/helpers')
-
-const TYPES = require('../../di/types')
 
 const { getTimeframeQuery } = require('../dao/helpers')
 const {
   SyncedPositionsSnapshotParamsError
 } = require('../../errors')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SyncSchema,
+  TYPES.CurrencyConverter,
+  TYPES.Authenticator
+]
 class PositionsSnapshot {
   constructor (
     rService,
@@ -636,12 +639,6 @@ class PositionsSnapshot {
   }
 }
 
-decorate(injectable(), PositionsSnapshot)
-decorate(inject(TYPES.RService), PositionsSnapshot, 0)
-decorate(inject(TYPES.DAO), PositionsSnapshot, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), PositionsSnapshot, 2)
-decorate(inject(TYPES.SyncSchema), PositionsSnapshot, 3)
-decorate(inject(TYPES.CurrencyConverter), PositionsSnapshot, 4)
-decorate(inject(TYPES.Authenticator), PositionsSnapshot, 5)
+decorateInjectable(PositionsSnapshot, depsTypes)
 
 module.exports = PositionsSnapshot

--- a/workers/loc.api/sync/progress/index.js
+++ b/workers/loc.api/sync/progress/index.js
@@ -2,17 +2,19 @@
 
 const EventEmitter = require('events')
 const { isEmpty } = require('lodash')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const {
   tryParseJSON
 } = require('../../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.WSEventEmitter,
+  TYPES.Logger
+]
 class Progress extends EventEmitter {
   constructor (
     dao,
@@ -70,10 +72,6 @@ class Progress extends EventEmitter {
   }
 }
 
-decorate(injectable(), Progress)
-decorate(inject(TYPES.DAO), Progress, 0)
-decorate(inject(TYPES.TABLES_NAMES), Progress, 1)
-decorate(inject(TYPES.WSEventEmitter), Progress, 2)
-decorate(inject(TYPES.Logger), Progress, 3)
+decorateInjectable(Progress, depsTypes)
 
 module.exports = Progress

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -8,7 +8,7 @@
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
 
-const SUPPORTED_DB_VERSION = 21
+const SUPPORTED_DB_VERSION = 22
 
 const TABLES_NAMES = require('./tables-names')
 const {
@@ -773,6 +773,7 @@ const _models = new Map([
     {
       _id: ID_PRIMARY_KEY,
       collName: 'VARCHAR(255)',
+      mts: 'BIGINT',
       user_id: 'INT NOT NULL',
 
       [UNIQUE_INDEX_FIELD_NAME]: ['collName', 'user_id'],

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -8,7 +8,7 @@
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
 
-const SUPPORTED_DB_VERSION = 22
+const SUPPORTED_DB_VERSION = 23
 
 const TABLES_NAMES = require('./tables-names')
 const {
@@ -293,6 +293,7 @@ const _models = new Map([
       fees: 'DECIMAL(22,12)',
       destinationAddress: 'VARCHAR(255)',
       transactionId: 'VARCHAR(255)',
+      note: 'TEXT',
       subUserId: 'INT',
       user_id: 'INT NOT NULL',
 

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -774,7 +774,7 @@ const _models = new Map([
       _id: ID_PRIMARY_KEY,
       collName: 'VARCHAR(255)',
       mts: 'BIGINT',
-      user_id: 'INT NOT NULL',
+      user_id: 'INT',
 
       [UNIQUE_INDEX_FIELD_NAME]: ['collName', 'user_id'],
       [CONSTR_FIELD_NAME]: `CONSTRAINT #{tableName}_fk_user_id

--- a/workers/loc.api/sync/schema/sync-schema.js
+++ b/workers/loc.api/sync/schema/sync-schema.js
@@ -22,6 +22,7 @@ const _methodCollMap = new Map([
       sort: [['mts', -1], ['id', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.LEDGERS)
     }
@@ -36,6 +37,7 @@ const _methodCollMap = new Map([
       sort: [['mtsCreate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.TRADES)
     }
@@ -50,6 +52,7 @@ const _methodCollMap = new Map([
       sort: [['mtsCreate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.FUNDING_TRADES)
     }
@@ -65,6 +68,7 @@ const _methodCollMap = new Map([
       hasNewData: false,
       start: [],
       confName: 'publicTradesConf',
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.PUBLIC_TRADES)
     }
@@ -88,6 +92,7 @@ const _methodCollMap = new Map([
       sort: [['timestamp', -1]],
       hasNewData: true,
       confName: 'statusMessagesConf',
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.STATUS_MESSAGES)
     }
@@ -102,6 +107,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.ORDERS)
     }
@@ -116,6 +122,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdated', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.MOVEMENTS)
     }
@@ -130,6 +137,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.FUNDING_OFFER_HISTORY)
     }
@@ -144,6 +152,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.FUNDING_LOAN_HISTORY)
     }
@@ -158,6 +167,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.FUNDING_CREDIT_HISTORY)
     }
@@ -172,6 +182,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.POSITIONS_HISTORY)
     }
@@ -186,6 +197,7 @@ const _methodCollMap = new Map([
       sort: [['mtsUpdate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.POSITIONS_SNAPSHOT)
     }
@@ -200,6 +212,7 @@ const _methodCollMap = new Map([
       sort: [['time', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.LOGINS)
     }
@@ -214,6 +227,7 @@ const _methodCollMap = new Map([
       sort: [['mtsCreate', -1]],
       hasNewData: false,
       start: [],
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CHANGE_LOGS)
     }
@@ -229,6 +243,7 @@ const _methodCollMap = new Map([
       hasNewData: false,
       start: [],
       confName: 'tickersHistoryConf',
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.TICKERS_HISTORY)
     }
@@ -244,6 +259,7 @@ const _methodCollMap = new Map([
       subQuery: {
         sort: [['mts', -1], ['id', -1]]
       },
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.HIDDEN_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.LEDGERS),
       dataStructureConverter: (accum, {
@@ -274,6 +290,7 @@ const _methodCollMap = new Map([
       field: 'pairs',
       sort: [['pairs', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
       model: getModelOf(TABLES_NAMES.SYMBOLS)
     }
@@ -286,6 +303,7 @@ const _methodCollMap = new Map([
       fields: ['key', 'value'],
       sort: [['key', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.MAP_SYMBOLS)
     }
@@ -298,6 +316,7 @@ const _methodCollMap = new Map([
       field: 'pairs',
       sort: [['pairs', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
       model: getModelOf(TABLES_NAMES.INACTIVE_CURRENCIES)
     }
@@ -310,6 +329,7 @@ const _methodCollMap = new Map([
       field: 'pairs',
       sort: [['pairs', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
       model: getModelOf(TABLES_NAMES.INACTIVE_SYMBOLS)
     }
@@ -322,6 +342,7 @@ const _methodCollMap = new Map([
       field: 'pairs',
       sort: [['pairs', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
       model: getModelOf(TABLES_NAMES.FUTURES)
     }
@@ -334,6 +355,7 @@ const _methodCollMap = new Map([
       fields: ['id'],
       sort: [['name', 1]],
       hasNewData: true,
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CURRENCIES)
     }
@@ -350,6 +372,7 @@ const _methodCollMap = new Map([
       hasNewData: false,
       start: [],
       confName: 'candlesConf',
+      isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CANDLES)
     }

--- a/workers/loc.api/sync/schema/sync-schema.js
+++ b/workers/loc.api/sync/schema/sync-schema.js
@@ -372,6 +372,7 @@ const _methodCollMap = new Map([
       hasNewData: false,
       start: [],
       confName: 'candlesConf',
+      isSyncDoneForCurrencyConv: false,
       isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CANDLES)

--- a/workers/loc.api/sync/sub.account.api.data/index.js
+++ b/workers/loc.api/sync/sub.account.api.data/index.js
@@ -1,10 +1,6 @@
 'use strict'
 
 const {
-  decorate,
-  injectable
-} = require('inversify')
-const {
   orderBy,
   isEmpty
 } = require('lodash')
@@ -19,6 +15,8 @@ const {
 const {
   DatePropNameError
 } = require('../../errors')
+
+const { decorateInjectable } = require('../../di/utils')
 
 class SubAccountApiData {
   _hasId (id) {
@@ -322,6 +320,6 @@ class SubAccountApiData {
   }
 }
 
-decorate(injectable(), SubAccountApiData)
+decorateInjectable(SubAccountApiData)
 
 module.exports = SubAccountApiData

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -140,28 +140,28 @@ class SubAccount {
         )
         const auth = isAuthCheckedInDb
           ? await this.authenticator.verifyUser(
-            {
-              auth: {
-                email,
-                password,
-                token
+              {
+                auth: {
+                  email,
+                  password,
+                  token
+                }
+              },
+              {
+                projection: [
+                  '_id',
+                  'id',
+                  'email',
+                  'apiKey',
+                  'apiSecret',
+                  'timezone',
+                  'username'
+                ],
+                isDecryptedApiKeys: true,
+                isNotInTrans: true,
+                withoutWorkerThreads: true
               }
-            },
-            {
-              projection: [
-                '_id',
-                'id',
-                'email',
-                'apiKey',
-                'apiSecret',
-                'timezone',
-                'username'
-              ],
-              isDecryptedApiKeys: true,
-              isNotInTrans: true,
-              withoutWorkerThreads: true
-            }
-          )
+            )
           : { apiKey, apiSecret }
 
         if (
@@ -406,28 +406,28 @@ class SubAccount {
         )
         const auth = isAuthCheckedInDb
           ? await this.authenticator.verifyUser(
-            {
-              auth: {
-                email,
-                password,
-                token
+              {
+                auth: {
+                  email,
+                  password,
+                  token
+                }
+              },
+              {
+                projection: [
+                  '_id',
+                  'id',
+                  'email',
+                  'apiKey',
+                  'apiSecret',
+                  'timezone',
+                  'username'
+                ],
+                isDecryptedApiKeys: true,
+                isNotInTrans: true,
+                withoutWorkerThreads: true
               }
-            },
-            {
-              projection: [
-                '_id',
-                'id',
-                'email',
-                'apiKey',
-                'apiSecret',
-                'timezone',
-                'username'
-              ],
-              isDecryptedApiKeys: true,
-              isNotInTrans: true,
-              withoutWorkerThreads: true
-            }
-          )
+            )
           : { apiKey, apiSecret }
 
         const existedSubUser = subUsers.find((subUser) => (

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -62,7 +62,8 @@ class SubAccount {
             'apiSecret',
             'timezone',
             'username',
-            'password'
+            'password',
+            'isNotProtected'
           ],
           isDecryptedApiKeys: true,
           isReturnedPassword: true,
@@ -70,12 +71,17 @@ class SubAccount {
         }
       )
 
-    const _subAccountPassword = (
+    const isSubAccountPwdEntered = (
       subAccountPassword &&
       typeof subAccountPassword === 'string'
     )
+    const _subAccountPassword = isSubAccountPwdEntered
       ? subAccountPassword
       : masterUser.password
+    const isNotProtected = (
+      !isSubAccountPwdEntered &&
+      masterUser.isNotProtected
+    )
 
     if (
       isSubAccountApiKeys(masterUser) ||
@@ -89,7 +95,8 @@ class SubAccount {
     const subAccount = {
       ...masterUser,
       ...getSubAccountAuthFromAuth(masterUser),
-      password: _subAccountPassword
+      password: _subAccountPassword,
+      isNotProtected
     }
 
     return this.dao.executeQueriesInTrans(async () => {
@@ -187,7 +194,8 @@ class SubAccount {
             {
               auth: {
                 ...auth,
-                password: _subAccountPassword
+                password: _subAccountPassword,
+                isNotProtected
               }
             },
             {

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -1,15 +1,9 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   AuthError
 } = require('bfx-report/workers/loc.api/errors')
 
-const TYPES = require('../../di/types')
 const {
   isSubAccountApiKeys,
   getSubAccountAuthFromAuth
@@ -20,6 +14,14 @@ const {
   UserRemovingError
 } = require('../../errors')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.Authenticator,
+  TYPES.Sync
+]
 class SubAccount {
   constructor (
     dao,
@@ -560,10 +562,6 @@ class SubAccount {
   }
 }
 
-decorate(injectable(), SubAccount)
-decorate(inject(TYPES.DAO), SubAccount, 0)
-decorate(inject(TYPES.TABLES_NAMES), SubAccount, 1)
-decorate(inject(TYPES.Authenticator), SubAccount, 2)
-decorate(inject(TYPES.Sync), SubAccount, 3)
+decorateInjectable(SubAccount, depsTypes)
 
 module.exports = SubAccount

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -27,12 +27,18 @@ class SyncCollsManager {
   async hasCollBeenSyncedAtLeastOnce (params) {
     const {
       userId,
+      subUserId,
       collName
     } = { ...params }
 
+    const subUserIdFilter = Number.isInteger(subUserId)
+      ? { subUserId }
+      : {}
+
     const completedColl = await this._getCompletedCollBy({
       user_id: userId,
-      collName
+      collName,
+      ...subUserIdFilter
     })
 
     return (
@@ -45,6 +51,7 @@ class SyncCollsManager {
   setCollAsSynced (params) {
     const {
       userId,
+      subUserId,
       collName
     } = { ...params }
 
@@ -53,6 +60,7 @@ class SyncCollsManager {
       {
         collName,
         mts: Date.now(),
+        subUserId,
         user_id: userId
       },
       { isReplacedIfExists: true }

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -5,18 +5,17 @@ const {
 } = require('bfx-report/workers/loc.api/errors')
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../di/types')
-
-const {
   isHidden,
   isPublic
 } = require('../schema/utils')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.SyncSchema
+]
 class SyncCollsManager {
   constructor (
     dao,
@@ -291,9 +290,6 @@ class SyncCollsManager {
   }
 }
 
-decorate(injectable(), SyncCollsManager)
-decorate(inject(TYPES.DAO), SyncCollsManager, 0)
-decorate(inject(TYPES.TABLES_NAMES), SyncCollsManager, 1)
-decorate(inject(TYPES.SyncSchema), SyncCollsManager, 2)
+decorateInjectable(SyncCollsManager, depsTypes)
 
 module.exports = SyncCollsManager

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -82,7 +82,6 @@ class SyncCollsManager {
         $isNull: ['user_id']
       }
     })
-    console.log('[completedColls]:'.bgBlue, completedColls)
 
     if (
       !Array.isArray(completedColls) ||
@@ -101,7 +100,6 @@ class SyncCollsManager {
     }
 
     const checkingRes = []
-    const names = []
 
     for (const [method, schema] of this._methodCollMap) {
       const {
@@ -123,7 +121,6 @@ class SyncCollsManager {
         ))
 
         checkingRes.push(isDone)
-        names.push(method)
 
         continue
       }
@@ -142,7 +139,6 @@ class SyncCollsManager {
         ))
 
         checkingRes.push(isDone)
-        names.push(method)
 
         continue
       }
@@ -155,11 +151,8 @@ class SyncCollsManager {
       ))
 
       checkingRes.push(isDone)
-      names.push(method)
     }
 
-    console.log('[checkingRes]:'.bgGreen, checkingRes)
-    console.log('[names]:'.bgGreen, names)
     return checkingRes.every((res) => res)
   }
 

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -41,6 +41,23 @@ class SyncCollsManager {
       completedColl.collName === collName
     )
   }
+
+  setCollAsSynced (params) {
+    const {
+      userId,
+      collName
+    } = { ...params }
+
+    return this.dao.insertElemToDb(
+      this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
+      {
+        collName,
+        mts: Date.now(),
+        user_id: userId
+      },
+      { isReplacedIfExists: true }
+    )
+  }
 }
 
 decorate(injectable(), SyncCollsManager)

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -16,6 +16,31 @@ class SyncCollsManager {
     this.dao = dao
     this.TABLES_NAMES = TABLES_NAMES
   }
+
+  _getCompletedCollBy (params = {}) {
+    return this.dao.getElemInCollBy(
+      this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
+      params
+    )
+  }
+
+  async hasCollBeenSyncedAtLeastOnce (params) {
+    const {
+      userId,
+      collName
+    } = { ...params }
+
+    const completedColl = await this._getCompletedCollBy({
+      user_id: userId,
+      collName
+    })
+
+    return (
+      completedColl &&
+      typeof completedColl === 'object' &&
+      completedColl.collName === collName
+    )
+  }
 }
 
 decorate(injectable(), SyncCollsManager)

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const TYPES = require('../../di/types')
+
+class SyncCollsManager {
+  constructor (
+    dao,
+    TABLES_NAMES
+  ) {
+    this.dao = dao
+    this.TABLES_NAMES = TABLES_NAMES
+  }
+}
+
+decorate(injectable(), SyncCollsManager)
+decorate(inject(TYPES.DAO), SyncCollsManager, 0)
+decorate(inject(TYPES.TABLES_NAMES), SyncCollsManager, 1)
+
+module.exports = SyncCollsManager

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -1,6 +1,10 @@
 'use strict'
 
 const {
+  AuthError
+} = require('bfx-report/workers/loc.api/errors')
+
+const {
   decorate,
   injectable,
   inject
@@ -8,19 +12,35 @@ const {
 
 const TYPES = require('../../di/types')
 
+const {
+  isHidden,
+  isPublic
+} = require('../schema/utils')
+
 class SyncCollsManager {
   constructor (
     dao,
-    TABLES_NAMES
+    TABLES_NAMES,
+    syncSchema
   ) {
     this.dao = dao
     this.TABLES_NAMES = TABLES_NAMES
+    this.syncSchema = syncSchema
+
+    this._methodCollMap = this.syncSchema.getMethodCollMap()
   }
 
-  _getCompletedCollBy (params = {}) {
+  _getCompletedCollBy (filter = {}) {
     return this.dao.getElemInCollBy(
       this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
-      params
+      filter
+    )
+  }
+
+  _getCompletedCollsBy (filter = {}) {
+    return this.dao.getElemsInCollBy(
+      this.TABLES_NAMES.COMPLETED_ON_FIRST_SYNC_COLLS,
+      { filter }
     )
   }
 
@@ -48,6 +68,101 @@ class SyncCollsManager {
     )
   }
 
+  async haveCollsBeenSyncedAtLeastOnce (args) {
+    const { auth } = { ...args }
+    const {
+      _id: userId,
+      subUsers,
+      isSubAccount
+    } = auth
+
+    const completedColls = await this._getCompletedCollsBy({
+      $or: {
+        $eq: { user_id: userId },
+        $isNull: ['user_id']
+      }
+    })
+    console.log('[completedColls]:'.bgBlue, completedColls)
+
+    if (
+      !Array.isArray(completedColls) ||
+      completedColls.length === 0
+    ) {
+      return false
+    }
+    if (
+      isSubAccount &&
+      (
+        !Array.isArray(subUsers) ||
+        subUsers.length === 0
+      )
+    ) {
+      throw new AuthError()
+    }
+
+    const checkingRes = []
+    const names = []
+
+    for (const [method, schema] of this._methodCollMap) {
+      const {
+        type,
+        isSyncRequiredAtLeastOnce
+      } = schema
+
+      if (
+        isHidden(type) ||
+        !isSyncRequiredAtLeastOnce
+      ) {
+        continue
+      }
+      if (isPublic(type)) {
+        const isDone = completedColls.some((completedColl) => (
+          completedColl &&
+          typeof completedColl === 'object' &&
+          completedColl.collName === method
+        ))
+
+        checkingRes.push(isDone)
+        names.push(method)
+
+        continue
+      }
+      if (isSubAccount) {
+        const isDone = subUsers.every((subUser) => (
+          subUser &&
+          typeof subUser === 'object' &&
+          Number.isInteger(subUser._id) &&
+          completedColls.some((completedColl) => (
+            completedColl &&
+            typeof completedColl === 'object' &&
+            completedColl.collName === method &&
+            completedColl.user_id === userId &&
+            completedColl.subUserId === subUser._id
+          ))
+        ))
+
+        checkingRes.push(isDone)
+        names.push(method)
+
+        continue
+      }
+
+      const isDone = completedColls.some((completedColl) => (
+        completedColl &&
+        typeof completedColl === 'object' &&
+        completedColl.collName === method &&
+        completedColl.user_id === userId
+      ))
+
+      checkingRes.push(isDone)
+      names.push(method)
+    }
+
+    console.log('[checkingRes]:'.bgGreen, checkingRes)
+    console.log('[names]:'.bgGreen, names)
+    return checkingRes.every((res) => res)
+  }
+
   setCollAsSynced (params) {
     const {
       userId,
@@ -71,5 +186,6 @@ class SyncCollsManager {
 decorate(injectable(), SyncCollsManager)
 decorate(inject(TYPES.DAO), SyncCollsManager, 0)
 decorate(inject(TYPES.TABLES_NAMES), SyncCollsManager, 1)
+decorate(inject(TYPES.SyncSchema), SyncCollsManager, 2)
 
 module.exports = SyncCollsManager

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -191,7 +191,7 @@ class SyncCollsManager {
     const { _id: userId } = auth
     const {
       schema,
-      commonAllowedDiffInMs = 2 * 60 * 60 * 1000
+      commonAllowedDiffInMs = 24 * 60 * 60 * 1000
     } = { ...params }
 
     const completedColls = await this._getCompletedCollsBy({

--- a/workers/loc.api/sync/sync.interrupter/index.js
+++ b/workers/loc.api/sync/sync.interrupter/index.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const {
-  decorate,
-  injectable
-} = require('inversify')
-
 const Interrupter = require(
   'bfx-report/workers/loc.api/interrupter'
 )
+
+const { decorateInjectable } = require('../../di/utils')
 
 class SyncInterrupter extends Interrupter {
   constructor () {
@@ -65,6 +62,6 @@ class SyncInterrupter extends Interrupter {
   }
 }
 
-decorate(injectable(), SyncInterrupter)
+decorateInjectable(SyncInterrupter)
 
 module.exports = SyncInterrupter

--- a/workers/loc.api/sync/sync.queue/index.js
+++ b/workers/loc.api/sync/sync.queue/index.js
@@ -2,13 +2,7 @@
 
 const EventEmitter = require('events')
 const { isEmpty } = require('lodash')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const COLLS_TYPES = require('../schema/colls.types')
 
 const {
@@ -25,6 +19,17 @@ const {
   ERROR_JOB_STATE
 } = require('./sync.queue.states')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.TABLES_NAMES,
+  TYPES.ALLOWED_COLLS,
+  TYPES.DAO,
+  TYPES.DataInserterFactory,
+  TYPES.Progress,
+  TYPES.SyncSchema,
+  TYPES.SyncInterrupter
+]
 class SyncQueue extends EventEmitter {
   constructor (
     TABLES_NAMES,
@@ -341,13 +346,6 @@ class SyncQueue extends EventEmitter {
   }
 }
 
-decorate(injectable(), SyncQueue)
-decorate(inject(TYPES.TABLES_NAMES), SyncQueue, 0)
-decorate(inject(TYPES.ALLOWED_COLLS), SyncQueue, 1)
-decorate(inject(TYPES.DAO), SyncQueue, 2)
-decorate(inject(TYPES.DataInserterFactory), SyncQueue, 3)
-decorate(inject(TYPES.Progress), SyncQueue, 4)
-decorate(inject(TYPES.SyncSchema), SyncQueue, 5)
-decorate(inject(TYPES.SyncInterrupter), SyncQueue, 6)
+decorateInjectable(SyncQueue, depsTypes)
 
 module.exports = SyncQueue

--- a/workers/loc.api/sync/traded.volume/index.js
+++ b/workers/loc.api/sync/traded.volume/index.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.Trades
+]
 class TradedVolume {
   constructor (
     trades
@@ -23,7 +20,6 @@ class TradedVolume {
   }
 }
 
-decorate(injectable(), TradedVolume)
-decorate(inject(TYPES.Trades), TradedVolume, 0)
+decorateInjectable(TradedVolume, depsTypes)
 
 module.exports = TradedVolume

--- a/workers/loc.api/sync/trades/index.js
+++ b/workers/loc.api/sync/trades/index.js
@@ -1,21 +1,26 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   splitSymbolPairs
 } = require('bfx-report/workers/loc.api/helpers')
 
-const TYPES = require('../../di/types')
 const {
   calcGroupedData,
   groupByTimeframe,
   getMtsGroupedByTimeframe
 } = require('../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SyncSchema,
+  TYPES.FOREX_SYMBS,
+  TYPES.CurrencyConverter,
+  TYPES.Authenticator,
+  TYPES.SYNC_API_METHODS
+]
 class Trades {
   constructor (
     dao,
@@ -313,13 +318,6 @@ class Trades {
   }
 }
 
-decorate(injectable(), Trades)
-decorate(inject(TYPES.DAO), Trades, 0)
-decorate(inject(TYPES.ALLOWED_COLLS), Trades, 1)
-decorate(inject(TYPES.SyncSchema), Trades, 2)
-decorate(inject(TYPES.FOREX_SYMBS), Trades, 3)
-decorate(inject(TYPES.CurrencyConverter), Trades, 4)
-decorate(inject(TYPES.Authenticator), Trades, 5)
-decorate(inject(TYPES.SYNC_API_METHODS), Trades, 6)
+decorateInjectable(Trades, depsTypes)
 
 module.exports = Trades

--- a/workers/loc.api/sync/wallets/index.js
+++ b/workers/loc.api/sync/wallets/index.js
@@ -1,13 +1,14 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.CurrencyConverter,
+  TYPES.TABLES_NAMES,
+  TYPES.Authenticator,
+  TYPES.SYNC_API_METHODS
+]
 class Wallets {
   constructor (
     dao,
@@ -115,11 +116,6 @@ class Wallets {
   }
 }
 
-decorate(injectable(), Wallets)
-decorate(inject(TYPES.DAO), Wallets, 0)
-decorate(inject(TYPES.CurrencyConverter), Wallets, 1)
-decorate(inject(TYPES.TABLES_NAMES), Wallets, 2)
-decorate(inject(TYPES.Authenticator), Wallets, 3)
-decorate(inject(TYPES.SYNC_API_METHODS), Wallets, 4)
+decorateInjectable(Wallets, depsTypes)
 
 module.exports = Wallets

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -1,13 +1,7 @@
 'use strict'
 
 const moment = require('moment')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const {
   calcGroupedData,
   groupByTimeframe,
@@ -15,6 +9,19 @@ const {
   getStartMtsByTimeframe
 } = require('../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.ALLOWED_COLLS,
+  TYPES.Wallets,
+  TYPES.BalanceHistory,
+  TYPES.PositionsSnapshot,
+  TYPES.FOREX_SYMBS,
+  TYPES.Authenticator,
+  TYPES.SYNC_API_METHODS
+]
 class WinLoss {
   constructor (
     dao,
@@ -403,15 +410,6 @@ class WinLoss {
   }
 }
 
-decorate(injectable(), WinLoss)
-decorate(inject(TYPES.DAO), WinLoss, 0)
-decorate(inject(TYPES.SyncSchema), WinLoss, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), WinLoss, 2)
-decorate(inject(TYPES.Wallets), WinLoss, 3)
-decorate(inject(TYPES.BalanceHistory), WinLoss, 4)
-decorate(inject(TYPES.PositionsSnapshot), WinLoss, 5)
-decorate(inject(TYPES.FOREX_SYMBS), WinLoss, 6)
-decorate(inject(TYPES.Authenticator), WinLoss, 7)
-decorate(inject(TYPES.SYNC_API_METHODS), WinLoss, 8)
+decorateInjectable(WinLoss, depsTypes)
 
 module.exports = WinLoss

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -265,10 +265,7 @@ class WSTransport {
 
       try {
         if (
-          (
-            typeof handler !== 'function' &&
-            handler === null
-          ) ||
+          handler === null ||
           (
             isEmittedToActiveUsers &&
             !this._isActiveUser(user)

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -278,6 +278,14 @@ class WSTransport {
           ? await handler(user, { ...args, action })
           : handler
 
+        if (
+          res &&
+          typeof res === 'object' &&
+          res.isNotEmitted
+        ) {
+          continue
+        }
+
         this._sendToOne(socket, sid, action, null, res)
       } catch (err) {
         this._sendToOne(socket, sid, action, err)

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -3,18 +3,22 @@
 const uuid = require('uuid')
 const { omit } = require('lodash')
 const { PeerRPCServer } = require('grenache-nodejs-ws')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../di/types')
 
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
 
+const { decorateInjectable } = require('../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.CONF,
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.Link,
+  TYPES.GRC_BFX_OPTS,
+  TYPES.TABLES_NAMES,
+  TYPES.Authenticator
+]
 class WSTransport {
   constructor (
     { wsPort },
@@ -333,13 +337,6 @@ class WSTransport {
   }
 }
 
-decorate(injectable(), WSTransport)
-decorate(inject(TYPES.CONF), WSTransport, 0)
-decorate(inject(TYPES.RService), WSTransport, 1)
-decorate(inject(TYPES.DAO), WSTransport, 2)
-decorate(inject(TYPES.Link), WSTransport, 3)
-decorate(inject(TYPES.GRC_BFX_OPTS), WSTransport, 4)
-decorate(inject(TYPES.TABLES_NAMES), WSTransport, 5)
-decorate(inject(TYPES.Authenticator), WSTransport, 6)
+decorateInjectable(WSTransport, depsTypes)
 
 module.exports = WSTransport

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -29,6 +29,32 @@ class WSEventEmitter {
     )
   }
 
+  emitSyncingStep (
+    handler = () => {}
+  ) {
+    return this.wsTransport.sendToActiveUsers(
+      handler,
+      'emitSyncingStep'
+    )
+  }
+
+  emitSyncingStepToOne (
+    handler = () => {},
+    auth = {}
+  ) {
+    return this.emitSyncingStep((user, ...args) => {
+      if (
+        !auth ||
+        typeof auth !== 'object' ||
+        user._id !== auth._id
+      ) {
+        return
+      }
+
+      return handler(user, ...args)
+    })
+  }
+
   async emitRedirectingRequestsStatusToApi (
     handler = () => {}
   ) {

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -42,7 +42,7 @@ class WSEventEmitter {
     handler = () => {},
     auth = {}
   ) {
-    return this.emitSyncingStep((user, ...args) => {
+    return this.emitSyncingStep(async (user, ...args) => {
       if (
         !auth ||
         typeof auth !== 'object' ||
@@ -51,7 +51,9 @@ class WSEventEmitter {
         return
       }
 
-      return handler(user, ...args)
+      return typeof handler === 'function'
+        ? await handler(user, ...args)
+        : handler
     })
   }
 

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../di/utils')
 
-const TYPES = require('../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.WSTransport
+]
 class WSEventEmitter {
   constructor (wsTransport) {
     this.wsTransport = wsTransport
@@ -67,7 +64,6 @@ class WSEventEmitter {
   }
 }
 
-decorate(injectable(), WSEventEmitter)
-decorate(inject(TYPES.WSTransport), WSEventEmitter, 0)
+decorateInjectable(WSEventEmitter, depsTypes)
 
 module.exports = WSEventEmitter

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -48,7 +48,7 @@ class WSEventEmitter {
         typeof auth !== 'object' ||
         user._id !== auth._id
       ) {
-        return
+        return { isNotEmitted: true }
       }
 
       return typeof handler === 'function'


### PR DESCRIPTION
This PR adds a helper to decorate injectable class of modules to improve readability and reduce the writing code of new modules. It's refactoring related to this PR of the main repo https://github.com/bitfinexcom/bfx-report/pull/219

instead of:
```js
const {
  decorate,
  injectable,
  inject
} = require('inversify')

const TYPES = require('../../di/types')

class SyncCollsManager {
  constructor (
    dao,
    TABLES_NAMES,
    syncSchema
  ) {
    this.dao = dao
    this.TABLES_NAMES = TABLES_NAMES
    this.syncSchema = syncSchema
  }
}

decorate(injectable(), SyncCollsManager)
decorate(inject(TYPES.DAO), SyncCollsManager, 0)
decorate(inject(TYPES.TABLES_NAMES), SyncCollsManager, 1)
decorate(inject(TYPES.SyncSchema), SyncCollsManager, 2)

module.exports = SyncCollsManager
```

writes as shown bellow:
```js
const { decorateInjectable } = require('../../di/utils')

const depsTypes = (TYPES) => [
  TYPES.DAO,
  TYPES.TABLES_NAMES,
  TYPES.SyncSchema
]
class SyncCollsManager {
  constructor (
    dao,
    TABLES_NAMES,
    syncSchema
  ) {
    this.dao = dao
    this.TABLES_NAMES = TABLES_NAMES
    this.syncSchema = syncSchema
  }
}

decorateInjectable(SyncCollsManager, depsTypes)

module.exports = SyncCollsManager
```