### PR TITLE
Don't check change logs have been synced at least once

### DIFF
--- a/test/helpers/helpers.tests.js
+++ b/test/helpers/helpers.tests.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { assert } = require('chai')
+
+const testCsvPathHasCommonFolder = ({ aggrRes }) => {
+  aggrRes.newFilePaths.forEach((newFilePath) => {
+    // example: reports/csv/user_full-tax-report_FROM_Fri-Dec-01-2017_TO_Fri-May-28-2021/user_full-tax-report_END_SNAPSHOT_Tue-Jun-08-2021.csv
+    assert.match(
+      newFilePath,
+      /csv\/[A-Za-z0-9\-_]+\/[A-Za-z0-9\-_]+\.csv$/,
+      'Has csv common folder for group reports'
+    )
+  })
+}
+
+module.exports = {
+  testCsvPathHasCommonFolder
+}

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -13,6 +13,9 @@ const {
   delay,
   getParamsArrToTestTimeframeGrouping
 } = require('../helpers/helpers.core')
+const {
+  testCsvPathHasCommonFolder
+} = require('../helpers/helpers.tests')
 
 module.exports = (
   agent,
@@ -699,7 +702,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getFullTaxReportCsv method for starting snapshot, store csv to local folder', async function () {
@@ -724,7 +732,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getFullTaxReportCsv method for ending snapshot, store csv to local folder', async function () {
@@ -749,7 +762,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getTradedVolumeCsv method', async function () {

--- a/workers/loc.api/sync/schema/sync-schema.js
+++ b/workers/loc.api/sync/schema/sync-schema.js
@@ -227,7 +227,7 @@ const _methodCollMap = new Map([
       sort: [['mtsCreate', -1]],
       hasNewData: false,
       start: [],
-      isSyncRequiredAtLeastOnce: true,
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CHANGE_LOGS)
     }


### PR DESCRIPTION
This PR fixes launching the app for the first time, the issue is following: we should not check that `change logs` have been synced at least once due to some fresh users may not have entries in that tables. And it would initiate a sync every time when the app launches