### PR TITLE
[Wait] Bump better-sqlite3 driver version up to 7.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "better-npm-run": "^0.1.1",
-    "better-sqlite3": "7.1.2",
+    "better-sqlite3": "7.4.1",
     "bfx-facs-db-better-sqlite": "git+https://github.com/bitfinexcom/bfx-facs-db-better-sqlite.git",
     "bfx-facs-scheduler": "git+https://github.com:bitfinexcom/bfx-facs-scheduler.git",
     "bfx-report": "git+https://github.com/bitfinexcom/bfx-report.git",

--- a/test/helpers/helpers.tests.js
+++ b/test/helpers/helpers.tests.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { assert } = require('chai')
+
+const testCsvPathHasCommonFolder = ({ aggrRes }) => {
+  aggrRes.newFilePaths.forEach((newFilePath) => {
+    // example: reports/csv/user_full-tax-report_FROM_Fri-Dec-01-2017_TO_Fri-May-28-2021/user_full-tax-report_END_SNAPSHOT_Tue-Jun-08-2021.csv
+    assert.match(
+      newFilePath,
+      /csv\/[A-Za-z0-9\-_]+\/[A-Za-z0-9\-_]+\.csv$/,
+      'Has csv common folder for group reports'
+    )
+  })
+}
+
+module.exports = {
+  testCsvPathHasCommonFolder
+}

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -13,6 +13,9 @@ const {
   delay,
   getParamsArrToTestTimeframeGrouping
 } = require('../helpers/helpers.core')
+const {
+  testCsvPathHasCommonFolder
+} = require('../helpers/helpers.tests')
 
 module.exports = (
   agent,
@@ -699,7 +702,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getFullTaxReportCsv method for starting snapshot, store csv to local folder', async function () {
@@ -724,7 +732,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getFullTaxReportCsv method for ending snapshot, store csv to local folder', async function () {
@@ -749,7 +762,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getTradedVolumeCsv method', async function () {


### PR DESCRIPTION
This PR bumps version of the `better-sqlite3` DB driver up to `7.4.1`. The reasons are the following:
  - the driver reached a point to have pre-built binaries for all OS (win, mac, linux) for the electron env, https://github.com/JoshuaWise/better-sqlite3/releases/tag/v7.4.1 This means that we can don't care about it and remove ugly fix from the `bfx-report-electron` repo, removing `better-sqlite3` pre-build binary for windows https://github.com/bitfinexcom/bfx-report-electron/blob/master/build/better-sqlite3-prebuild-bin-win/better_sqlite3.zip
  - added prebuilt binaries for Electron `v13`. This means that we can use Nodejs `v14` with the last features