### PR TITLE
Add result to win/loss for time period

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",
     "bfx-api-mock-srv": "git+https://github.com/bitfinexcom/bfx-api-mock-srv.git",
-    "grenache-grape": "^0.9.8",
+    "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
     "mocha": "^6.1.4",
     "chai": "^4.2.0",
     "nodemon": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grenache-grape": "^0.9.8",
     "mocha": "^6.1.4",
     "chai": "^4.2.0",
-    "nodemon": "^1.18.10",
+    "nodemon": "^2.0.7",
     "supertest": "^4.0.2",
     "standard": "^16.0.3"
   },

--- a/test/helpers/helpers.core.js
+++ b/test/helpers/helpers.core.js
@@ -26,7 +26,7 @@ const delay = (mc = 500) => _delay(mc)
 
 const getParamsArrToTestTimeframeGrouping = (
   params = {},
-  timeframes = ['day', 'month', 'year']
+  timeframes = ['day', 'week', 'month', 'year']
 ) => {
   return Array(timeframes.length)
     .fill({ ...params })

--- a/test/helpers/helpers.tests.js
+++ b/test/helpers/helpers.tests.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { assert } = require('chai')
+
+const testCsvPathHasCommonFolder = ({ aggrRes }) => {
+  aggrRes.newFilePaths.forEach((newFilePath) => {
+    // example: reports/csv/user_full-tax-report_FROM_Fri-Dec-01-2017_TO_Fri-May-28-2021/user_full-tax-report_END_SNAPSHOT_Tue-Jun-08-2021.csv
+    assert.match(
+      newFilePath,
+      /csv\/[A-Za-z0-9\-_]+\/[A-Za-z0-9\-_]+\.csv$/,
+      'Has csv common folder for group reports'
+    )
+  })
+}
+
+module.exports = {
+  testCsvPathHasCommonFolder
+}

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -13,6 +13,9 @@ const {
   delay,
   getParamsArrToTestTimeframeGrouping
 } = require('../helpers/helpers.core')
+const {
+  testCsvPathHasCommonFolder
+} = require('../helpers/helpers.tests')
 
 module.exports = (
   agent,
@@ -699,7 +702,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getFullTaxReportCsv method for starting snapshot, store csv to local folder', async function () {
@@ -724,7 +732,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getFullTaxReportCsv method for ending snapshot, store csv to local folder', async function () {
@@ -749,7 +762,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getTradedVolumeCsv method', async function () {

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -632,6 +632,34 @@ module.exports = (
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getFullSnapshotReportCsv method, store csv to local folder', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(params.processorQueue)
+    const aggrPromise = queueToPromise(params.aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getFullSnapshotReportCsv',
+        params: {
+          end
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
+  })
+
   it('it should be successfully performed by the getPositionsSnapshotCsv method', async function () {
     this.timeout(60000)
 

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -234,26 +234,42 @@ class CsvJobData extends BaseCsvJobData {
       uInfo
     )
     const { params } = { ...args }
-    const { chunkCommonFolder } = { ...opts }
+    const { username } = { ...uInfo }
+
     const {
+      end,
       isStartSnapshot,
       isEndSnapshot
     } = { ...params }
-    const isBaseNameInName = isStartSnapshot || isEndSnapshot
-    const typeName = isStartSnapshot
+    const {
+      isFullTaxReport,
+      chunkCommonFolder: _chunkCommonFolder
+    } = { ...opts }
+    const _typeName = isStartSnapshot
       ? 'START_SNAPSHOT'
       : 'END_SNAPSHOT'
-    const fileName = isBaseNameInName
+    const typeName = (isStartSnapshot || isEndSnapshot)
+      ? _typeName
+      : 'MOMENT'
+    const fileName = isFullTaxReport
       ? `full-tax-report_${typeName}`
-      : 'full-snapshot-report'
+      : `full-snapshot-report_${typeName}`
+
+    const endDate = end
+      ? getDateString(end)
+      : getDateString()
+    const uName = username ? `${username}_` : ''
+    const chunkCommonFolder = (
+      _chunkCommonFolder &&
+      typeof _chunkCommonFolder === 'string'
+    )
+      ? _chunkCommonFolder
+      : `${uName}full-snapshot-report_TO_${endDate}`
 
     const csvArgs = getCsvArgs(
       args,
       null,
-      {
-        isOnMomentInName: !isBaseNameInName,
-        isBaseNameInName
-      }
+      { isBaseNameInName: true }
     )
 
     const jobData = {
@@ -368,7 +384,10 @@ class CsvJobData extends BaseCsvJobData {
         },
         uId,
         uInfo,
-        { chunkCommonFolder }
+        {
+          chunkCommonFolder,
+          isFullTaxReport: true
+        }
       )
     }
 

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -170,6 +170,7 @@ const paramsSchemaForRiskApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -204,6 +205,7 @@ const paramsSchemaForBalanceHistoryApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -242,6 +244,7 @@ const paramsSchemaForFullTaxReportApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -262,6 +265,7 @@ const paramsSchemaForWinLossApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -282,6 +286,7 @@ const paramsSchemaForTradedVolumeApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -305,6 +310,7 @@ const paramsSchemaForFeesReportApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -328,6 +334,7 @@ const paramsSchemaForPerformingLoanApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -163,41 +163,6 @@ const paramsSchemaForEditCandlesСonf = {
   }
 }
 
-const paramsSchemaForRiskApi = {
-  type: 'object',
-  properties: {
-    timeframe: {
-      type: 'string',
-      enum: [
-        'day',
-        'week',
-        'month',
-        'year'
-      ]
-    },
-    start: {
-      type: 'integer'
-    },
-    end: {
-      type: 'integer'
-    },
-    skip: {
-      type: 'array',
-      minItems: 1,
-      maxItems: 3,
-      items: {
-        type: 'string',
-        enum: [
-          'trades',
-          'marginTrades',
-          'fundingPayment',
-          'movementFees'
-        ]
-      }
-    }
-  }
-}
-
 const paramsSchemaForBalanceHistoryApi = {
   type: 'object',
   properties: {
@@ -240,15 +205,6 @@ const paramsSchemaForFullSnapshotReportApi = {
 const paramsSchemaForFullTaxReportApi = {
   type: 'object',
   properties: {
-    timeframe: {
-      type: 'string',
-      enum: [
-        'day',
-        'week',
-        'month',
-        'year'
-      ]
-    },
     end: {
       type: 'integer'
     },
@@ -356,15 +312,6 @@ const {
   dateFormat
 } = { ...paramsSchemaForCsv.properties }
 
-const paramsSchemaForRiskCsv = {
-  type: 'object',
-  properties: {
-    ...cloneDeep(paramsSchemaForRiskApi.properties),
-    timezone,
-    dateFormat
-  }
-}
-
 const paramsSchemaForBalanceHistoryCsv = {
   type: 'object',
   properties: {
@@ -456,7 +403,6 @@ module.exports = {
   paramsSchemaForEditCandlesСonf,
   paramsSchemaForCreateSubAccount,
   paramsSchemaForUpdateSubAccount,
-  paramsSchemaForRiskApi,
   paramsSchemaForBalanceHistoryApi,
   paramsSchemaForWinLossApi,
   paramsSchemaForPositionsSnapshotApi,
@@ -466,7 +412,6 @@ module.exports = {
   paramsSchemaForFeesReportApi,
   paramsSchemaForPerformingLoanApi,
   paramsSchemaForCandlesApi,
-  paramsSchemaForRiskCsv,
   paramsSchemaForBalanceHistoryCsv,
   paramsSchemaForWinLossCsv,
   paramsSchemaForPositionsSnapshotCsv,

--- a/workers/loc.api/sync/balance.history/index.js
+++ b/workers/loc.api/sync/balance.history/index.js
@@ -165,6 +165,9 @@ class BalanceHistory {
     if (timeframe === 'month') {
       mtsMoment.add(1, 'months')
     }
+    if (timeframe === 'week') {
+      mtsMoment.add(1, 'weeks')
+    }
     if (timeframe === 'year') {
       mtsMoment.add(1, 'years')
     }

--- a/workers/loc.api/sync/dao/helpers/get-timeframe-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-timeframe-query.js
@@ -7,11 +7,12 @@ module.exports = (timeframe, params) => {
   } = { ...params }
 
   const day = timeframe === 'day' ? '-%m-%d' : ''
+  const week = timeframe === 'week' ? '-%W' : ''
   const month = timeframe === 'month' ? '-%m' : ''
   const year = '%Y'
 
   return `strftime(
-    '${year}${month}${day}',
+    '${year}${month}${week}${day}',
     ${propName}/1000,
     'unixepoch'
   ) AS ${alias}`

--- a/workers/loc.api/sync/helpers/get-mts-grouped-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/get-mts-grouped-by-timeframe.js
@@ -42,6 +42,11 @@ module.exports = (
 
       continue
     }
+    if (timeframe === 'week') {
+      currMoment.add(1, 'weeks')
+
+      continue
+    }
     if (timeframe === 'month') {
       currMoment.add(1, 'months')
 

--- a/workers/loc.api/sync/helpers/get-start-mts-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/get-start-mts-by-timeframe.js
@@ -1,24 +1,35 @@
 'use strict'
 
+const moment = require('moment')
+
 module.exports = (ts, timeframe = 'year') => {
-  const date = ts instanceof Date ? ts : new Date(ts)
-  const year = date.getUTCFullYear()
-  const month = date.getUTCMonth()
-  const day = date.getUTCDate()
+  const date = moment.utc(ts)
+
+  const year = date.year()
+  const month = date.month()
+  const weekYear = date.isoWeekYear()
+  const week = date.isoWeek()
+  const day = date.dayOfYear()
+
+  const momentDate = moment.utc({ year })
 
   if (timeframe === 'day') {
-    return Date.UTC(
-      year,
-      month,
-      day
-    )
+    momentDate.dayOfYear(day)
+
+    return momentDate.valueOf()
+  }
+  if (timeframe === 'week') {
+    momentDate.isoWeekYear(weekYear)
+    momentDate.isoWeekday(1)
+    momentDate.isoWeek(week)
+
+    return momentDate.valueOf()
   }
   if (timeframe === 'month') {
-    return Date.UTC(
-      year,
-      month
-    )
+    momentDate.month(month)
+
+    return momentDate.valueOf()
   }
 
-  return Date.UTC(year)
+  return momentDate.valueOf()
 }

--- a/workers/loc.api/sync/helpers/group-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/group-by-timeframe.js
@@ -63,6 +63,14 @@ const _isMonthlyTimeframe = (params) => {
   return _checkTimeframe(params)
 }
 
+const _isWeeklyTimeframe = (params) => {
+  if (params.timeframe !== 'week') {
+    return false
+  }
+
+  return _checkTimeframe(params)
+}
+
 const _isDailyTimeframe = (params) => {
   if (params.timeframe !== 'day') {
     return false
@@ -83,6 +91,7 @@ const _isNotEmptyGroupItem = ({ mts, vals }) => {
 const _isTimeframe = (timeframe) => {
   return (
     timeframe === 'day' ||
+    timeframe === 'week' ||
     timeframe === 'month' ||
     timeframe === 'year'
   )
@@ -205,6 +214,20 @@ module.exports = async (
       continue
     }
     if (_isMonthlyTimeframe(paramsToCheck)) {
+      const groupItem = await _getGroupItem(
+        subRes,
+        timeframe,
+        symbol,
+        dateFieldName,
+        symbolFieldName,
+        calcDataFn
+      )
+
+      _addFragment(res, subRes, groupItem)
+
+      continue
+    }
+    if (_isWeeklyTimeframe(paramsToCheck)) {
       const groupItem = await _getGroupItem(
         subRes,
         timeframe,

--- a/workers/loc.api/sync/schema/sync-schema.js
+++ b/workers/loc.api/sync/schema/sync-schema.js
@@ -227,7 +227,7 @@ const _methodCollMap = new Map([
       sort: [['mtsCreate', -1]],
       hasNewData: false,
       start: [],
-      isSyncRequiredAtLeastOnce: true,
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CHANGE_LOGS)
     }

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -109,6 +109,7 @@ class WinLoss {
     endPl = {}
   ) {
     let prevMovementsRes = {}
+    let prevRes = 0
 
     return ({
       walletsGroupedByTimeframe = {},
@@ -148,9 +149,13 @@ class WinLoss {
           return { ...accum }
         }
 
+        const timePeriodRes = res - prevRes
+        prevRes = res
+
         return {
           ...accum,
-          [symb]: res
+          [symb]: res,
+          [`timePeriod${symb}`]: timePeriodRes
         }
       }, {})
     }

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -250,6 +250,9 @@ class WinLoss {
       if (timeframe === 'day') {
         mtsMoment.add(1, 'days')
       }
+      if (timeframe === 'week') {
+        mtsMoment.add(1, 'weeks')
+      }
       if (timeframe === 'month') {
         mtsMoment.add(1, 'months')
       }


### PR DESCRIPTION
This PR adds the result to the `win/loss` response for the time period

Request example:

```jsonc
{
    "auth": {
        "token": "some-token"
    },
    "method": "getWinLoss",
    "params": {
        "start": 1587020627000,
        "end": 1597800919000,
        "timeframe": "month"
    }
}
```

Response example:

```jsonc
{
  "result": [
    {
      "mts": 1597800919000,
      "USD": -123.3220999,
      "timePeriodUSD": 555.555 // where curr "USD": -123.3220999 - prev "USD": -678.8770999
    },
    {
      "mts": 1596240000000,
      "USD": -678.8770999,
      "timePeriodUSD": -333.333 // where curr "USD": -678.8770999 - prev "USD": -345.5440999
    },
    {
      "mts": 1593561600000,
      "USD": -345.5440999,
      "timePeriodUSD": 777.777 // where curr "USD": -345.5440999 - prev "USD": -1123.3211
    },
    {
      "mts": 1590969600000,
      "USD": -1123.3211,
      "timePeriodUSD": 111.111 // where curr "USD": -1123.3211 - prev "USD": -1234.4321
    },
    {
      "mts": 1588291200000,
      "USD": -1234.4321,
      "timePeriodUSD": -1234.4321
    },
    {
      "mts": 1587020627000,
      "USD": 0
    }
  ],
  "id": null
}
```

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/170